### PR TITLE
Remove  pubnum v2

### DIFF
--- a/_data/conferencepapers.yml
+++ b/_data/conferencepapers.yml
@@ -1,7 +1,6 @@
 ---
 
 id_conferencepaper_dis2014:
-  pubnum: C.52
   authors:
     - id_author_epstein_daniel
     - id_author_cordeiro_felicia
@@ -16,7 +15,6 @@ id_conferencepaper_dis2014:
   localpdf: dis2014.pdf
 
 id_conferencepaper_avi2014:
-  pubnum: C.51
   authors:
     - id_author_hipke_kyle
     - id_author_toomim_michael
@@ -31,7 +29,6 @@ id_conferencepaper_avi2014:
   localvideo: avi2014.mp4
 
 id_conferencepaper_chi2014_prefab:
-  pubnum: C.50
   authors:
     - id_author_dixon_morgan
     - id_author_laput_gierad
@@ -45,7 +42,6 @@ id_conferencepaper_chi2014_prefab:
   localvideo: chi2014-prefab.mp4
 
 id_conferencepaper_chi2014_gesturescript:
-  pubnum: C.49
   authors:
     - id_author_lu_hao
     - id_author_fogarty_james
@@ -59,7 +55,6 @@ id_conferencepaper_chi2014_gesturescript:
   localvideo: chi2014-gesturescript.mp4
 
 id_conferencepaper_ubicomp2013:
-  pubnum: C.48
   authors:
     - id_author_epstein_daniel
     - id_author_borning_alan
@@ -73,7 +68,6 @@ id_conferencepaper_ubicomp2013:
   localvideo: ubicomp2013.mp4
 
 id_conferencepaper_pervasivehealth2013:
-  pubnum: C.47
   authors:
     - id_author_andrew_adrienne
     - id_author_borriello_gaetano
@@ -86,7 +80,6 @@ id_conferencepaper_pervasivehealth2013:
   localpdf: pervasivehealth2013.pdf
 
 id_conferencepaper_uist2012:
-  pubnum: C.46
   authors:
     - id_author_roesner_franzi
     - id_author_fogarty_james
@@ -99,7 +92,6 @@ id_conferencepaper_uist2012:
   localpdf: uist2012.pdf
 
 id_conferencepaper_chi2012-prefab:
-  pubnum: C.45
   authors:
     - id_author_dixon_morgan
     - id_author_fogarty_james
@@ -113,7 +105,6 @@ id_conferencepaper_chi2012-prefab:
   localvideo: chi2012-prefab.mp4
 
 id_conferencepaper_chi2012_regroup:
-  pubnum: C.44
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -126,7 +117,6 @@ id_conferencepaper_chi2012_regroup:
   localpdf: chi2012-regroup.pdf
 
 id_conferencepaper_vlhcc2011:
-  pubnum: C.43
   authors:
     - id_author_ziola_ryder
     - id_author_grampurohit_shweta
@@ -141,7 +131,6 @@ id_conferencepaper_vlhcc2011:
   localpdf: vlhcc2011.pdf
 
 id_conferencepaper_aaai2011:
-  pubnum: C.42
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -155,7 +144,6 @@ id_conferencepaper_aaai2011:
   localpdf: aaai2011.pdf
 
 id_conferencepaper_ijcai2011:
-  pubnum: C.41
   authors:
     - id_author_patel_kayur
     - id_author_drucker_steven
@@ -170,7 +158,6 @@ id_conferencepaper_ijcai2011:
   localpdf: ijcai2011.pdf
 
 id_conferencepaper_fdg2011:
-  pubnum: C.40
   authors:
     - id_author_cooper_seth
     - id_author_khatib_firas
@@ -189,7 +176,6 @@ id_conferencepaper_fdg2011:
   localpdf: fdg2011.pdf
 
 id_conferencepaper_dgo2011:
-  pubnum: C.39
   authors:
     - id_author_munson_sean
     - id_author_avrahami_daniel
@@ -205,7 +191,6 @@ id_conferencepaper_dgo2011:
   localpdf: dgo2011.pdf
 
 id_conferencepaper_pervasive2011:
-  pubnum: C.38
   authors:
     - id_author_froehlich_jon
     - id_author_larson_eric
@@ -222,7 +207,6 @@ id_conferencepaper_pervasive2011:
   localpdf: pervasive2011.pdf
 
 id_conferencepaper_chi2011:
-  pubnum: C.37
   authors:
     - id_author_dixon_morgan
     - id_author_leventhal_daniel
@@ -236,7 +220,6 @@ id_conferencepaper_chi2011:
   localvideo: chi2011.mp4
 
 id_conferencepaper_uist2010:
-  pubnum: C.36
   authors:
     - id_author_patel_kayur
     - id_author_bancroft_naomi
@@ -253,7 +236,6 @@ id_conferencepaper_uist2010:
   localvideo: uist2010.mp4
 
 id_conferencepaper_pervasive2010:
-  pubnum: C.35
   authors:
     - id_author_welbourne_evan
     - id_author_balazinska_magdalena
@@ -267,7 +249,6 @@ id_conferencepaper_pervasive2010:
   localpdf: pervasive2010.pdf
 
 id_conferencepaper_dgo2010:
-  pubnum: C.34
   authors:
     - id_author_kriplean_travis
     - id_author_borning_alan
@@ -282,7 +263,6 @@ id_conferencepaper_dgo2010:
   localpdf: dgo2010.pdf
 
 id_conferencepaper_chi2010_prefab:
-  pubnum: C.33
   authors:
     - id_author_dixon_morgan
     - id_author_fogarty_james
@@ -295,7 +275,6 @@ id_conferencepaper_chi2010_prefab:
   localvideo: chi2010-prefab.mp4
 
 id_conferencepaper_chi2010_cueflik:
-  pubnum: C.32
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -309,7 +288,6 @@ id_conferencepaper_chi2010_cueflik:
   localpdf: chi2010-cueflik.pdf
 
 id_conferencepaper_cikm2009:
-  pubnum: C.31
   authors:
     - id_author_lin_thomas
     - id_author_etzioni_oren
@@ -322,7 +300,6 @@ id_conferencepaper_cikm2009:
   localpdf: cikm2009.pdf
 
 id_conferencepaper_uist2009:
-  pubnum: C.30
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -336,7 +313,6 @@ id_conferencepaper_uist2009:
   localpdf: uist2009.pdf
 
 id_conferencepaper_ubicomp2009:
-  pubnum: C.29
   authors:
     - id_author_froehlich_jon
     - id_author_larson_eric
@@ -352,7 +328,6 @@ id_conferencepaper_ubicomp2009:
   localpdf: ubicomp2009.pdf
 
 id_conferencepaper_chi2009_kylin:
-  pubnum: C.28
   authors:
     - id_author_hoffmann_raphael
     - id_author_amershi_saleema
@@ -368,7 +343,6 @@ id_conferencepaper_chi2009_kylin:
   localpdf: chi2009-kylin.pdf
 
 id_conferencepaper_chi2009_graphicalpasswords:
-  pubnum: C.27
   authors:
     - id_author_everitt_katherine
     - id_author_bragin_tanya
@@ -382,7 +356,6 @@ id_conferencepaper_chi2009_graphicalpasswords:
   localpdf: chi2009-graphicalpasswords.pdf
 
 id_conferencepaper_chi2009_anglemouse:
-  pubnum: C.26
   authors:
     - id_author_wobbrock_jacob
     - id_author_fogarty_james
@@ -398,7 +371,6 @@ id_conferencepaper_chi2009_anglemouse:
   localvideo: chi2009-anglemouse.mp4
 
 id_conferencepaper_cscw2008:
-  pubnum: C.25
   authors:
     - id_author_campbell_taj
     - id_author_ngo_brian
@@ -411,7 +383,6 @@ id_conferencepaper_cscw2008:
   localpdf: cscw2008.pdf
 
 id_conferencepaper_uist2008:
-  pubnum: C.24
   authors:
     - id_author_adar_eytan
     - id_author_dontcheva_mira
@@ -426,7 +397,6 @@ id_conferencepaper_uist2008:
   localvideo: uist2008.mp4
 
 id_conferencepaper_icmi2008:
-  pubnum: C.23
   authors:
     - id_author_harada_susumu
     - id_author_lester_jonathan
@@ -443,7 +413,6 @@ id_conferencepaper_icmi2008:
   localpdf: icmi2008.pdf
 
 id_conferencepaper_aaai2008_learningtools:
-  pubnum: C.22
   authors:
     - id_author_patel_kayur
     - id_author_fogarty_james
@@ -457,7 +426,6 @@ id_conferencepaper_aaai2008_learningtools:
   localpdf: aaai2008-learningtools.pdf
 
 id_conferencepaper_aaai2008_wikipedia:
-  pubnum: C.21
   authors:
     - id_author_weld_daniel
     - id_author_wu_fei
@@ -475,7 +443,6 @@ id_conferencepaper_aaai2008_wikipedia:
   localpdf: aaai2008-wikipedia.pdf
 
 id_conferencepaper_gi2008:
-  pubnum: C.20
   authors:
     - id_author_lu_hao
     - id_author_fogarty_james
@@ -487,7 +454,6 @@ id_conferencepaper_gi2008:
   localpdf: gi2008.pdf
 
 id_conferencepaper_chi2008_cueflik:
-  pubnum: C.19
   authors:
     - id_author_fogarty_james
     - id_author_tan_desney
@@ -501,7 +467,6 @@ id_conferencepaper_chi2008_cueflik:
   localpdf: chi2008-cueflik.pdf
 
 id_conferencepaper_chi2008_learningtools:
-  pubnum: C.18
   authors:
     - id_author_patel_kayur
     - id_author_fogarty_james
@@ -515,7 +480,6 @@ id_conferencepaper_chi2008_learningtools:
   localpdf: chi2008-learningtools.pdf
 
 id_conferencepaper_chi2008_sharedknowledgequestions:
-  pubnum: C.17
   authors:
     - id_author_toomim_michael
     - id_author_zhang_xianhang
@@ -529,7 +493,6 @@ id_conferencepaper_chi2008_sharedknowledgequestions:
   localpdf: chi2008-sharedknowledgequestions.pdf
 
 id_conferencepaper_uist2007:
-  pubnum: C.16
   authors:
     - id_author_hoffmann_raphael
     - id_author_fogarty_james
@@ -542,7 +505,6 @@ id_conferencepaper_uist2007:
   localpdf: uist2007.pdf
 
 id_conferencepaper_chi2007_subtle:
-  pubnum: C.15
   authors:
     - id_author_fogarty_james
     - id_author_hudson_scott
@@ -554,7 +516,6 @@ id_conferencepaper_chi2007_subtle:
   localpdf: chi2007-subtle.pdf
 
 id_conferencepaper_chi2007_interruptibility:
-  pubnum: C.14
   authors:
     - id_author_avrahami_daniel
     - id_author_fogarty_james
@@ -567,7 +528,6 @@ id_conferencepaper_chi2007_interruptibility:
   localpdf: chi2007-interruptibility.pdf
 
 id_conferencepaper_chi2007_mentalmodels:
-  pubnum: C.13
   authors:
     - id_author_tullio_joe
     - id_author_dey_anind
@@ -581,7 +541,6 @@ id_conferencepaper_chi2007_mentalmodels:
   localpdf: chi2007-mentalmodels.pdf
 
 id_conferencepaper_persuasive2007:
-  pubnum: C.12
   authors:
     - id_author_andrew_adrienne
     - id_author_borriello_gaetano
@@ -594,7 +553,6 @@ id_conferencepaper_persuasive2007:
   localpdf: persuasive2007.pdf
 
 id_conferencepaper_uist2006:
-  pubnum: C.11
   authors:
     - id_author_fogarty_james
     - id_author_au_carolyn
@@ -607,7 +565,6 @@ id_conferencepaper_uist2006:
   localpdf: uist2006.pdf
 
 id_conferencepaper_chi2006:
-  pubnum: C.10
   authors:
     - id_author_tang_karen
     - id_author_keyani_pedram
@@ -621,7 +578,6 @@ id_conferencepaper_chi2006:
   localpdf: chi2006.pdf
 
 id_conferencepaper_gi2005:
-  pubnum: C.09
   authors:
     - id_author_fogarty_james
     - id_author_baker_ryan
@@ -634,7 +590,6 @@ id_conferencepaper_gi2005:
   localpdf: gi2005.pdf
 
 id_conferencepaper_chi2005:
-  pubnum: C.08
   authors:
     - id_author_fogarty_james
     - id_author_ko_andrew
@@ -650,7 +605,6 @@ id_conferencepaper_chi2005:
   localpdf: chi2005.pdf
 
 id_conferencepaper_chi2004:
-  pubnum: C.07
   authors:
     - id_author_fogarty_james
     - id_author_hudson_scott
@@ -663,7 +617,6 @@ id_conferencepaper_chi2004:
   localpdf: chi2004.pdf
 
 id_conferencepaper_uist2003:
-  pubnum: C.06
   authors:
     - id_author_fogarty_james
     - id_author_hudson_scott
@@ -675,7 +628,6 @@ id_conferencepaper_uist2003:
   localpdf: uist2003.pdf
 
 id_conferencepaper_gi2003:
-  pubnum: C.05
   authors:
     - id_author_fogarty_james
     - id_author_forlizzi_jodi
@@ -688,7 +640,6 @@ id_conferencepaper_gi2003:
   localpdf: gi2003.pdf
 
 id_conferencepaper_chi2003:
-  pubnum: C.04
   authors:
     - id_author_hudson_scott
     - id_author_fogarty_james
@@ -706,7 +657,6 @@ id_conferencepaper_chi2003:
   localpdf: chi2003.pdf
 
 id_conferencepaper_uist2002:
-  pubnum: C.03
   authors:
     - id_author_fogarty_james
     - id_author_forlizzi_jodi
@@ -719,7 +669,6 @@ id_conferencepaper_uist2002:
   localpdf: uist2002.pdf
 
 id_conferencepaper_uist2001:
-  pubnum: C.02
   authors:
     - id_author_fogarty_james
     - id_author_forlizzi_jodi
@@ -732,7 +681,6 @@ id_conferencepaper_uist2001:
   localpdf: uist2001.pdf
 
 id_conferencepaper_aied2001:
-  pubnum: C.01
   authors:
     - id_author_fogarty_james
     - id_author_dabbish_laura

--- a/_data/journalpapers.yml
+++ b/_data/journalpapers.yml
@@ -1,7 +1,6 @@
 ---
 
 id_journalpaper_ip2012:
-  pubnum: J.05
   authors:
     - id_author_munson_sean
     - id_author_avrahami_daniel
@@ -20,7 +19,6 @@ id_journalpaper_ip2012:
   localpdf: ip2012.pdf
 
 id_journalpaper_pmc2012:
-  pubnum: J.04
   authors:
     - id_author_larson_eric
     - id_author_froehlich_jon
@@ -40,7 +38,6 @@ id_journalpaper_pmc2012:
   localpdf: pmc2012.pdf
 
 id_journalpaper_tochi2005:
-  pubnum: J.03
   authors:
     - id_author_fogarty_james
     - id_author_hudson_scott
@@ -61,7 +58,6 @@ id_journalpaper_tochi2005:
   localpdf: tochi2005.pdf
 
 id_journalpaper_ijhcs2004:
-  pubnum: J.02
   authors:
     - id_author_fogarty_james
     - id_author_lai_jennifer
@@ -77,7 +73,6 @@ id_journalpaper_ijhcs2004:
   localpdf: ijhcs2004.pdf
 
 id_journalpaper_ijhcs2001:
-  pubnum: J.01
   authors:
     - id_author_carroll_john
     - id_author_rosson_mary_beth

--- a/_data/remove-pubnum.py
+++ b/_data/remove-pubnum.py
@@ -1,0 +1,12 @@
+filenames = ['conferencepapers.yml','journalpapers.yml','workshoppapers.yml']
+
+for filename in filenames:
+	fin = open(filename,'r')
+	lines = fin.readlines()
+	fin.close()
+	fout = open(filename,'w')
+
+	for line in lines:
+		if 'pubnum' not in line:
+			fout.write(line)
+	fout.close()

--- a/_data/workshoppapers.yml
+++ b/_data/workshoppapers.yml
@@ -1,7 +1,6 @@
 ---
 
 id_workshoppaper_chi2013:
-  pubnum: W.19
   authors:
     - id_author_epstein_daniel
     - id_author_fogarty_james
@@ -10,7 +9,6 @@ id_workshoppaper_chi2013:
   localpdf: workshop-chi2013.pdf
 
 id_workshoppaper_chi2012_interactivemachinelearning:
-  pubnum: W.18
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -19,7 +17,6 @@ id_workshoppaper_chi2012_interactivemachinelearning:
   localpdf: workshop-chi2012-interactivemachinelearning.pdf
 
 id_workshoppaper_chi2012_personalinformatics:
-  pubnum: W.17
   authors:
     - id_author_andrew_adrienne
     - id_author_borriello_gaetano
@@ -29,7 +26,6 @@ id_workshoppaper_chi2012_personalinformatics:
   localpdf: workshop-chi2012-personalinformatics.pdf
 
 id_workshoppaper_nsfpecs2011:
-  pubnum: W.16
   authors:
     - id_author_fogarty_james
   title: 'Scaling Human Attention: End-User Interaction with Machine Learning in Pervasive Systems'
@@ -37,7 +33,6 @@ id_workshoppaper_nsfpecs2011:
   localpdf: workshop-nsfpecs2011.pdf
 
 id_workshoppaper_iui2011:
-  pubnum: W.15
   authors:
     - id_author_ziola_ryder
     - id_author_grampurohit_shweta
@@ -49,7 +44,6 @@ id_workshoppaper_iui2011:
   localpdf: workshop-iui2011.pdf
 
 id_workshoppaper_chi2010:
-  pubnum: W.14
   authors:
     - id_author_dixon_morgan
     - id_author_fogarty_james
@@ -58,7 +52,6 @@ id_workshoppaper_chi2010:
   localpdf: workshop-chi2010.pdf
 
 id_workshoppaper_nips2009:
-  pubnum: W.13
   authors:
     - id_author_amershi_saleema
     - id_author_fogarty_james
@@ -69,7 +62,6 @@ id_workshoppaper_nips2009:
   localpdf: workshop-nips2009.pdf
 
 id_workshoppaper_ijcai2009:
-  pubnum: W.12
   authors:
     - id_author_lin_thomas
     - id_author_etzioni_oren
@@ -79,7 +71,6 @@ id_workshoppaper_ijcai2009:
   localpdf: workshop-ijcai2009.pdf
 
 id_workshoppaper_chi2009_shareddatasets:
-  pubnum: W.11
   authors:
     - id_author_fogarty_james
   title: 'HCI is Different: We Need Something Else'
@@ -87,7 +78,6 @@ id_workshoppaper_chi2009_shareddatasets:
   localpdf: workshop-chi2009-shareddatasets.pdf
 
 id_workshoppaper_chi2009_consumptionfeedback:
-  pubnum: W.10
   authors:
     - id_author_froehlich_jon
     - id_author_everitt_katherine
@@ -98,7 +88,6 @@ id_workshoppaper_chi2009_consumptionfeedback:
   localpdf: workshop-chi2009-consumptionfeedback.pdf
 
 id_workshoppaper_chi2009_enduserprogramming:
-  pubnum: W.09
   authors:
     - id_author_adar_eytan
     - id_author_dontcheva_mira
@@ -109,7 +98,6 @@ id_workshoppaper_chi2009_enduserprogramming:
   localpdf: workshop-chi2009-enduserprogramming.pdf
 
 id_workshoppaper_chi2007:
-  pubnum: W.08
   authors:
     - id_author_campbell_taj
     - id_author_fogarty_james
@@ -118,7 +106,6 @@ id_workshoppaper_chi2007:
   localpdf: workshop-chi2007.pdf
 
 id_workshoppaper_chi2006:
-  pubnum: W.07
   authors:
     - id_author_fogarty_james
     - id_author_hong_jason
@@ -129,7 +116,6 @@ id_workshoppaper_chi2006:
   localpdf: workshop-chi2006.pdf
 
 id_workshoppaper_uist2004dc:
-  pubnum: W.06
   authors:
     - id_author_fogarty_james
   title: 'Constructing and Evaluating Sensor-Based Statistical Models of Human Interruptibility'
@@ -137,7 +123,6 @@ id_workshoppaper_uist2004dc:
   localpdf: workshop-uist2004dc.pdf
 
 id_workshoppaper_ibmhci2004:
-  pubnum: W.05
   authors:
     - id_author_fogarty_james
   title: 'Constructing and Evaluating Sensor-Based Statistical Models of Human Interruptibility'
@@ -145,7 +130,6 @@ id_workshoppaper_ibmhci2004:
   localpdf: workshop-ibmhci2004.pdf
 
 id_workshoppaper_ubicomp2004dc:
-  pubnum: W.04
   authors:
     - id_author_fogarty_james
   title: 'Constructing and Evaluating Sensor-Based Statistical Models of Human Interruptibility'
@@ -153,7 +137,6 @@ id_workshoppaper_ubicomp2004dc:
   localpdf: workshop-ubicomp2004dc.pdf
 
 id_workshoppaper_chi2004:
-  pubnum: W.03
   authors:
     - id_author_fogarty_james
   title: 'Connecting versus Calming: Interruptibility, Presence, and Availability'
@@ -161,7 +144,6 @@ id_workshoppaper_chi2004:
   localpdf: workshop-chi2004.pdf
 
 id_workshoppaper_pervasive2004:
-  pubnum: W.02
   authors:
     - id_author_fogarty_james
   title: 'AmIBusy: High-Level Abstraction in Ubiquitous Sensing Environments'
@@ -169,7 +151,6 @@ id_workshoppaper_pervasive2004:
   localpdf: workshop-pervasive2004.pdf
 
 id_workshoppaper_ubicomp2003:
-  pubnum: W.01
   authors:
     - id_author_fogarty_james
   title: 'Sensor Redundancy and Certain Privacy Concerns'


### PR DESCRIPTION
I may did something wrong with the branch "remove-pubnum" and it cannot be rebased and squashed. So I made a new branch called "remove--pubnum-v2" to make it right. Please don't merge the branch "remove-pubnum".

Sorry about that.
