### PR TITLE
Remove Fabric Deploy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -9,22 +9,10 @@ def build():
     fabric.api.local('jekyll build --config _config.yml')
 
 
-def deploy():
-    # Locally build the website
-    fabric.api.local('jekyll build --config _config.yml')
-
-    # Ensure the server has our staging directory
-    fabric.api.run('mkdir -p ~/fabric_staging/web-jayfo/')
-
-    # Ensure the staging directory is empty
-    fabric.api.run('rm -rf ~/fabric_staging/web-jayfo/*')
-
-    # Push up to the server staging directory
-    fabric.api.put('_site/*', '~/fabric_staging/web-jayfo/')
-
-    # And sync into the deployment directory
-    fabric.api.run('rsync -r -c --delete ~/fabric_staging/web-jayfo/ ~/public_html/')
-
+# Our deploy now happens via GitHub
+#
+# def deploy():
+#     pass
 
 def serve():
     fabric.api.local('jekyll serve --config _config.yml,_config-dev.yml --watch --force_polling')


### PR DESCRIPTION
The current fabric deploy command is a carryover from web-jayfo, and will overwrite that site if executed.