### PR TITLE
Added sidebar and content to 'Getting Involved'

### DIFF
--- a/gettinginvolved.md
+++ b/gettinginvolved.md
@@ -1,26 +1,108 @@
 ---
-layout: base/bar-sidebar-none
+layout: base/bar-sidebar-right
 title: "Getting Involved"
 title_secondary: "HCI & Design at the University of Washington"
 ---
-`do we want undergrads to get involved?`
 
-# Graduate Admissions
-Dub is not an academic department, but we do have our own degree program (MHCI+D) that is jointly offered by the four primary dub departments.
-In addition, students can participate in dub from any department at the University of Washington, and can apply to degree programs that are offered by these departments.
+<div class="sidebar_start"></div>
+  <a href="#mailing-list" class="list-group-item">Mailing List</a>
+  <a href="#seminar" class="list-group-item">DUB Seminar</a>
+  <a href="#prospective" class="list-group-item">Prospective Students</a> 
+<div class="sidebar_end"></div>
 
-- [Master of Human-Computer Interaction+Design](http://mhcid.washington.edu)
-- [Human Centered Design & Engineering](http://hdce.washington.edu)
-- [Information School](http://ischool.washington.edu)
-- [Computer Science and Engineering](http://cs.washington.edu)
-- [DXARTS Digital Arts](http://dxarts.washington.edu)
-- [IxD (Interaction Design) in Art / Division of Design](http://art.washington.edu/design)
-- [Biomedical and Health Informatics](http://bmhi.washington.edu)
+<div class="top_start"></div>
+`undergrads? industry sponsors? in general who to contact?`
+<div class="top_end"></div>
 
-More information about the graduate programs is available [here](/aboutdub.html).
-
-# Industry Sponsors
+<div id="mailing-list" markdown="1">
+-----------------
 
 # Mailing List
+-----------------
+The DUB mailing list is for students, faculty and industry partners with an interest in HCI/Design 
+and an affiliation to the University of Washington.
 
-Interested in joining the mailing list? Click [here](/mailinglists.html).
+To participate, please subscribe to **both**:
+
+#### The "everyone" list:
+- Subscribe to [dub](http://dub.washington.edu/mailman/listinfo/dub)... General announcements and information relating to dub.
+
+    *Note: You may only subscribe to this list with a valid UW or CSE email address.*
+
+#### ... And one of the following specific to you:
+- Subscribe to [dub-students](http://dub.washington.edu/mailman/listinfo/dub-students)... Student discussions
+- Subscribe to [dub-faculty](http://dub.washington.edu/mailman/listinfo/dub-faculty)... Faculty discussions
+- Subscribe to [dub-industry](http://dub.washington.edu/mailman/listinfo/dub-industry)... Industrial participant discussions
+- Subscribe to [dub-alumni](http://dub.washington.edu/mailman/listinfo/dub-alumni)... Alumni discussions
+
+Questions? Email `point of contact tbd`.
+
+</div>
+
+<div id="seminar" markdown="1">
+-----------------
+
+# DUB Seminar
+-----------------
+The weekly DUB seminar features talks from visiting researchers, industries, and our own DUB researchers.
+Members of DUB are all welcome and encouraged to attend the weekly DUB seminar. In addition, the seminar can be 
+taken for credit as CSE 590J or HCDE 523.
+
+Video recordings of the dub seminars are regularly uploaded onto the 
+[DesignUseBuild Vimeo channel](https://vimeo.com/designusebuild). 
+If you can't make it to the seminar, be sure to check out and subscribe to the channel to keep up with the latest 
+research in human-computer interaction and design.
+
+</div>
+
+<div id="prospective" markdown="1">
+-----------------
+
+# Prospective Students
+-----------------
+DUB is not an academic department, but we do have our own degree program (MHCI+D) that is jointly offered by the 
+four primary DUB departments (CSE, Design, HCDE, and the iSchool).
+
+In addition, students can participate in DUB from any department at the University of Washington, after they 
+have been accepted into one of the participating graduate degree programs.
+
+#### Ph.D. Programs
+
+Ph.D. students involved in DUB come from a variety of degree programs across the University of Washington campus.
+Students must apply and be accepted to one of the individual DUB departments. Students do, however, work 
+with faculty from across the many units involved in DUB; it is common to see joint advising by faculty 
+members in more than one department, and thesis committees often comprise members from multiple units. 
+We also see many collaborative student research projects across units and jointly co-authored papers.
+
+Please see the individual pages for each of the associated Ph.D. programs:
+
+- [Computer Science & Engineering](http://www.cs.washington.edu/prospective_students/grad)
+- [Human Centered Design & Engineering](http://www.hcde.washington.edu/phd)
+- [The Information School](https://ischool.uw.edu/future/phd)
+- [Biomedical & Health Informatics](http://www.bhi.washington.edu/welcomestudents)
+- [Electrical Engineering](http://www.ee.washington.edu/academics/graduate/index.html)
+- [DXARTS Digital Arts](http://dxarts.washington.edu/dxarts-phd)
+
+#### Master's Programs
+
+Four of the core departments involved in the DUB group (CSE, Design, HCDE, and the iSchool) identified a 
+need for a degree program that combined the diverse expertise of each of the core departments into a single 
+degree. The four departments came together and jointly designed, created, and sponsored a professional Master's 
+degree that focuses specifically on human-computer interaction and design. The result was the MHCI+D degree 
+mentioned above. The single year, full time, intensive degree program was launched in 2013 and is officially 
+hosted in the Graduate School. Faculty from the four core units teach in the program, and students take 
+electives directly from the four departments. The four departments also continue to offer their high quality, 
+individual graduate programs that go more in-depth in the specific fields. The demand is high for all of these 
+competitive, world-class programs.
+
+Below is information on the joint MHCI+D program and the individual degrees offered by the four core DUB units, 
+as well as related programs in other DUB units:
+
+- DUB: [Master of Human-Computer Interaction + Design (MHCI+D)](http://mhcid.washington.edu)
+- CSE: [Master of Science in Computer Science & Engineering (MS CSE)](http://www.cs.washington.edu/prospective_students/pmp)
+- HCDE: [Master of Science in Human Centered Design & Engineering (MS HCDE)](http://www.hcde.washington.edu/ms)
+- Design: [Master of Design in Interaction Design (MDes)](http://art.washington.edu/design/graduate/overview/)
+- iSchool: [Master of Science in Information Management (MSIM)](https://ischool.uw.edu/future/msim)
+- BHI: [Master of Science in Biomedical & Health Informatics (MS BHI)](http://www.bhi.washington.edu/welcomestudents)
+
+</div>


### PR DESCRIPTION
- Added sidebar and preliminary content to 'Getting Involved'.
- Moved admissions info from 'About DUB' to 'Getting Involved'
- Updated 'About DUB' with links to participating departments
- Laid some groundwork for fixed, floating sidebar (to be implemented in
future)