### PR TITLE
Updated 'About DUB' static content

### DIFF
--- a/aboutdub.md
+++ b/aboutdub.md
@@ -4,29 +4,27 @@ title: "About DUB"
 title_secondary: "HCI & Design at the University of Washington"
 ---
 
-`content needs to be finalized. consider putting admissions info on a separate page.`
-
 # What is DUB?
 
-The dub group is a grassroots, opt in alliance of faculty, students, researchers, and
+The DUB group is a grassroots, opt in alliance of faculty, students, researchers, and
 industry affiliates interested in human-computer interaction and design at the 
 University of Washington. The acronym DUB stands for Design, Use, Build. The 
-mission of dub is to bring together an interdisciplinary set of people to discuss
+mission of DUB is to bring together an interdisciplinary set of people to discuss
 issues, share ideas, collaborate on research projects, and discuss teaching concerns 
 related to the interaction between people and computers and major socio-technical 
 phenomena surrounding them.
 
-The dub group first began in 2003, when it was recognized that there was a strength 
+The DUB group first began in 2003, when it was recognized that there was a strength 
 of research in the area of human computer interaction and design across many units 
 on campus, and thus the idea of an alliance to bring these faculty, students, 
 researchers, and industry affiliates was born. 
 
-Members of the dub community come from many departments on campus, including 
+Members of the DUB community come from many departments on campus, including 
 Computer Science & Engineering, the Information School, Human Centered Design & 
 Engineering, the Division of Design in the School of Art, Biomedical & Health 
 Informatics, Electrical Engineering, Architecture, Communications, and Psychology. 
-However, dub welcomes anyone to participate regardless of their home department. 
-dub also has industry research affiliates from Microsoft, Intel, Google, Adobe, and 
+However, DUB welcomes anyone to participate regardless of their home department. 
+DUB also has industry research affiliates from Microsoft, Intel, Google, Adobe, and 
 others.
 
 The cornerstone activities of the dub group consist of: 
@@ -37,57 +35,25 @@ The cornerstone activities of the dub group consist of:
   smaller conferences such as CSCW, UIST, and ASSETS.
 - A yearly 1-day retreat for faculty, research-active students, and industry 
   affiliates.
-- In addition, the dub group leadership also leads the [Master of Human-Computer 
+- In addition, the DUB group leadership also leads the [Master of Human-Computer 
 Interaction & Design](http://mhcid.washington.edu) (MHCI+D) degree, which is sometimes 
-referred to as the "dub Master's degree." The degree is officially co-owned by 
+referred to as the "DUB Master's degree." The degree is officially co-owned by 
 Computer Science & Engineering, the Information School, Human Centered 
 Design & Engineering, and the Division of Design in the School of Art.
-Although only the MHCI+D degree is overseen by the dub group's leadership, other 
+Although only the MHCI+D degree is overseen by the DUB group's leadership, other 
 degree programs on campus are broadly related to human-computer interaction 
-and design. Some of them are described below.
+and design.
 
-# Ph.D. Programs
+The following are departments that serve as DUB units:
 
-Ph.D. students involved in dub come from a variety of degree programs across the 
-University of Washington campus. Students must apply and be accepted to one of 
-the individual dub departments. Students do, however, work with faculty from 
-across the many units involved in dub; it is common to see joint advising by faculty 
-members in more than one department, and thesis committees often comprise 
-members from multiple units. We also see many collaborative student research 
-projects across units and jointly co-authored papers.
+`link text below may be replaced with logos - thoughts?`
 
-Please see the individual pages for each of the associated Ph.D. programs:
+- [Master of Human-Computer Interaction+Design (MHCI+D)](http://mhcid.washington.edu)
+- [Human Centered Design & Engineering](http://hcde.washington.edu)
+- [Information School](http://ischool.washington.edu)
+- [Computer Science and Engineering](http://cs.washington.edu)
+- [IxD (Interaction Design) in Art / Division of Design](http://art.washington.edu/design)
+- [DXARTS Digital Arts](http://dxarts.washington.edu)
+- [Biomedical and Health Informatics](http://bhi.washington.edu)
 
-- [Computer Science & Engineering](http://www.cs.washington.edu/prospective_students/grad)
-- [Human Centered Design & Engineering](http://www.hcde.washington.edu/phd)
-- [The Information School](https://ischool.uw.edu/future/phd)
-- [Biomedical & Health Informatics](http://www.bhi.washington.edu/welcomestudents)
-- [Electrical Engineering](http://www.ee.washington.edu/academics/graduate/index.html)
-
-`Others?`
-
-# Master's Programs
-
-Four of the core departments involved in the dub group (CSE, Design, HCDE, and the 
-iSchool) identified a need for a degree program that combined the diverse expertise 
-of each of the core departments into a single degree. The four departments came 
-together and jointly designed, created, and sponsored a professional Master's 
-degree that focuses specifically on human-computer interaction and design. The 
-result was the MHCI+D degree mentioned above. The single year, full time, 
-intensive degree program was launched in 2013 and is officially hosted in the 
-Graduate School. Faculty from the four core units teach in the program, and students 
-take electives directly from the four departments. The four departments also 
-continue to offer their high quality, individual graduate programs that go more in-depth 
-in the specific fields. The demand is high for all of these competitive, world-class programs.
-
-Below is information on the joint MHCI+D program and the individual degrees 
-offered by the four core dub units, as well as related programs in other dub units:
-
-- dub: [Master of Human-Computer Interaction & Design (MHCI+D)](http://mhcid.washington.edu)
-- CSE: [Master of Science in Computer Science & Engineering (MS CSE)](http://www.cs.washington.edu/prospective_students/pmp)
-- Design: [Master of Design in Interaction Design (MDes)](http://art.washington.edu/design/graduate/overview/)
-- HCDE: [Master of Science in Human Centered Design & Engineering (MS HCDE)](http://www.hcde.washington.edu/ms)
-- iSchool: [Master of Science in Information Management (MSIM)](https://ischool.uw.edu/future/msim)
-- BHI: [Master of Science in Biomedical & Health Informatics (MS BHI)](http://www.bhi.washington.edu/welcomestudents)
-
-`Others?`
+`information about dub leadership and organization structure`


### PR DESCRIPTION
- Removed graduate program info (to be moved to 'Getting Involved')
- Added links to DUB unit department pages.

This is an update to #96.