### PR TITLE
Tweak Calendar Files

### DIFF
--- a/_seminars/2015-10-07.md
+++ b/_seminars/2015-10-07.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Carnegie Mellon University
 
-title:        ChangeDyslexia: Early Detection and Intervention at Large Scale
+title:        "ChangeDyslexia: Early Detection and Intervention at Large Scale"
 
 location:     HUB 145
 

--- a/_seminars/2015-10-07.md
+++ b/_seminars/2015-10-07.md
@@ -9,10 +9,7 @@ title:        "ChangeDyslexia: Early Detection and Intervention at Large Scale"
 
 location:     HUB 145
 
-date:
-  - year: 2015
-    month: 10
-    day: 07
+date:         2015-10-07
 
 abstract: >
   More than 10% of the population has dyslexia, and most are diagnosed only after they fail in school. My work is 

--- a/_seminars/2015-10-14.md
+++ b/_seminars/2015-10-14.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Microsoft Research
 
-title:        Leveraging Signals Generated From Search Engines and Web-based Resources
+title:        "Leveraging Signals Generated From Search Engines and Web-based Resources"
 
 location:     HUB 334
 

--- a/_seminars/2015-10-14.md
+++ b/_seminars/2015-10-14.md
@@ -9,10 +9,7 @@ title:        "Leveraging Signals Generated From Search Engines and Web-based Re
 
 location:     HUB 334
 
-date:
-  - year: 2015
-    month: 10
-    day: 14
+date:         2015-10-14
     
 abstract: >
   Search engines and web-based resources have become ubiquitous and essential tools for supporting the use of 

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -9,10 +9,7 @@ title:        "From Paid to Organic Crowdsourcing"
 
 location:     HUB 250 
 
-date:
-  - year: 2015
-    month: 10
-    day: 21
+date:         2015-10-21
     
 abstract: >
   Human computation systems seamlessly combine human perception, creativity and knowledge with machine-driven 

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Harvard University
 
-title:        From Paid to Organic Crowdsourcing
+title:        "From Paid to Organic Crowdsourcing"
 
 location:     HUB 250 
 

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Computer Science & Engineering
 
-title:        Interactive and Interpretable Machine Learning Models for Human Machine Collaboration
+title:        "Interactive and Interpretable Machine Learning Models for Human Machine Collaboration"
 
 location:     HUB 334 
 

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -9,10 +9,7 @@ title:        "Interactive and Interpretable Machine Learning Models for Human M
 
 location:     HUB 334 
 
-date:
-  - year: 2015
-    month: 10
-    day: 28
+date:         2015-10-28
     
 abstract: >
   I envision a system that enables successful collaborations between humans and machine learning models by harnessing 

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -9,10 +9,7 @@ title:        "Glass Fibers, Mental Models, Mobile Devices, and Electro Shocks"
 
 location:     HUB 334 
 
-date:
-  - year: 2015
-    month: 11
-    day: 04
+date:         2015-11-04
 
 abstract: >
   In this talk, I explore the higher dimensions of touch input. I show how to enable mobile devices to sense 3D 

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Microsoft Research
 
-title:        Glass Fibers, Mental Models, Mobile Devices, and Electro Shocks
+title:        "Glass Fibers, Mental Models, Mobile Devices, and Electro Shocks"
 
 location:     HUB 334 
 

--- a/_seminars/2015-11-18.md
+++ b/_seminars/2015-11-18.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Riot Games
 
-title:        67 million trials in 4 weeks: How online video games can change how we think about research, and how research can change how we design video games.
+title:        "67 million trials in 4 weeks: How online video games can change how we think about research, and how research can change how we design video games."
 
 location:     HUB 250
 

--- a/_seminars/2015-11-18.md
+++ b/_seminars/2015-11-18.md
@@ -9,10 +9,7 @@ title:        "67 million trials in 4 weeks: How online video games can change h
 
 location:     HUB 250
 
-date:
-  - year: 2015
-    month: 11
-    day: 18
+date:         2015-11-18
 
 abstract: >
   League of Legends is an online game with over 67 million players playing the game every month. As the developer of 

--- a/_seminars/2015-11-25.md
+++ b/_seminars/2015-11-25.md
@@ -9,10 +9,7 @@ title:        "Using Large-Scale Online Experiments to Design less WEIRD User In
 
 location:     HUB 334 
 
-date:
-  - year: 2015
-    month: 11
-    day: 25
+date:         2015-11-25
 
 abstract: >
   An estimated 95% of our scientific knowledge about people, their behavior, perception, and preferences is based on 

--- a/_seminars/2015-11-25.md
+++ b/_seminars/2015-11-25.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Computer Science & Engineering
 
-title:        Using Large-Scale Online Experiments to Design less WEIRD User Interfaces
+title:        "Using Large-Scale Online Experiments to Design less WEIRD User Interfaces"
 
 location:     HUB 334 
 

--- a/_seminars/2015-12-02.md
+++ b/_seminars/2015-12-02.md
@@ -11,7 +11,7 @@ name:
 
 affiliation:  Human Centered Design & Engineering
 
-title:        Building up STE(A)M : The UCD Charrette for K-12 Outreach
+title:        "Building up STE(A)M: The UCD Charrette for K-12 Outreach"
 
 location:     HUB 334
 

--- a/_seminars/2015-12-02.md
+++ b/_seminars/2015-12-02.md
@@ -15,10 +15,7 @@ title:        "Building up STE(A)M: The UCD Charrette for K-12 Outreach"
 
 location:     HUB 334
 
-date:
-  - year: 2015
-    month: 12
-    day: 02
+date:         2015-12-02
 
 abstract: >
   The imperative to inspire young students, especially under-represented minorities and women, to pursue education and 

--- a/_seminars/2015-12-09.md
+++ b/_seminars/2015-12-09.md
@@ -5,7 +5,7 @@ name:
 
 affiliation:  Cornell University
 
-title:        Understanding and Supporting Communication Across Linguistic Boundaries
+title:        "Understanding and Supporting Communication Across Linguistic Boundaries"
 
 location:     HUB 332
 

--- a/_seminars/2015-12-09.md
+++ b/_seminars/2015-12-09.md
@@ -9,10 +9,7 @@ title:        "Understanding and Supporting Communication Across Linguistic Boun
 
 location:     HUB 332
 
-date:
-  - year: 2015
-    month: 12
-    day: 09
+date:         2015-12-09
 
 abstract: >
   Computer-mediated communication (CMC) tools and social media potentially allow people to interact fluidly across 


### PR DESCRIPTION
Jekyll didn't like the colons in the "title" fields. Modified code structure to allow special characters in the "title" and "affiliation" fields.