### PR TITLE
Tweaks/Fixes To Seminars

### DIFF
--- a/_includes/seminartable.md
+++ b/_includes/seminartable.md
@@ -9,8 +9,14 @@
             <h4>
               {{ item_seminar.date | date: "%m/%d/%y"}}
             </h4>
-            {{ item_seminar.time }}
-            &nbsp;{{ item_seminar.location }}
+            <div class="pull-left">
+              {{ item_seminar.time }}&nbsp;
+            </div>
+            <div class="pull-left">
+              {{ item_seminar.location }}
+            </div>
+            <div class="clearfix">
+            </div>
           </div>
           <div class="col-md-10">
             <h4>

--- a/_includes/seminartable.md
+++ b/_includes/seminartable.md
@@ -25,12 +25,16 @@
               </a>
             </h4>
             {% for item_names in item_seminar.name %}
-                {% for item_name in item_names offset: 1 %}
-                  {{ item_name }}
-                {% endfor %}
+              {% for item_name in item_names offset: 1 %}
+                {{ item_name }}
+              {% endfor %}
+              {% if forloop.last %}
                 {{ item_names[0] }}
-                <br />
+              {% else %}
+                {{ item_names[0] | append:',' }}
+              {% endif %}
             {% endfor %}
+            <br />
             {{ item_seminar.affiliation }}
           </div>
           <div class="col-md-12">

--- a/_includes/seminartableprevious.md
+++ b/_includes/seminartableprevious.md
@@ -9,8 +9,14 @@
             <h4>
               {{ item_seminar.date | date: "%m/%d/%y"}}
             </h4>
-            {{ item_seminar.time }}
-            &nbsp;{{ item_seminar.location }}
+            <div class="pull-left">
+              {{ item_seminar.time }}&nbsp;
+            </div>
+            <div class="pull-left">
+              {{ item_seminar.location }}
+            </div>
+            <div class="clearfix">
+            </div>
           </div>
           <div class="col-md-10">
             <h4>

--- a/_includes/seminartableprevious.md
+++ b/_includes/seminartableprevious.md
@@ -25,12 +25,16 @@
               </a>
             </h4>
             {% for item_names in item_seminar.name %}
-                {% for item_name in item_names offset: 1 %}
-                  {{ item_name }}
-                {% endfor %}
+              {% for item_name in item_names offset: 1 %}
+                {{ item_name }}
+              {% endfor %}
+              {% if forloop.last %}
                 {{ item_names[0] }}
-                <br />
+              {% else %}
+                {{ item_names[0] | append:',' }}
+              {% endif %}
             {% endfor %}
+            <br />
             {{ item_seminar.affiliation }}
           </div>
           <div class="col-md-12">

--- a/_layouts/seminar.html
+++ b/_layouts/seminar.html
@@ -12,62 +12,71 @@
 {% assign item_seminar = page %}
 
 <!-- Main -->
-<div class="container" id="main">
+<div class="container" id="base-main">
     <!-- Bar -->
     <div class="row" id="bar">
         <div class="col-md-6" id="bar-primary">
-            <h1>
-                Seminar
-            </h1>
+            <h1>Seminar</h1>
         </div>
         <div class="col-md-6" id="bar-secondary">
+            <p>HCI & Design at the University of Washington</p>
         </div>
     </div>
     <!-- Bar End -->
 
-    <!-- Content -->
-    <div id="content">
-        <div class="row">
-            <div class="col-md-2">
-                <h4>Date</h4>
-                {{ item_seminar.date | date: '%B %d, %Y'}}
-                <h4>Time</h4>
-                {{ item_seminar.time }}
-                <h4>Location</h4>
-                {{ item_seminar.location }}
-            </div>
-            <div class="col-md-10">
-                <h4>Title</h4>
-                {{ item_seminar.title }}
-                <h4>Speaker</h4>
-                {% for item_names in item_seminar.name %}
-                    {% for item_name in item_names offset: 1 %}
-                        {{ item_name }}
+    <div class="row base-content">
+        <div class="col-md-12">
+            <div class="row">
+                <div class="col-md-4 col-md-push-8">
+                    <a href="/calendar.html" class="list-group-item">Upcoming Seminars</a>
+                    <a href="/previousseminars.html" class="list-group-item">Previous Seminars</a>
+                </div>
+                <div class="col-md-6 col-md-pull-2">
+                    <h4>Title</h4>
+                    {{ item_seminar.title }}
+                    {% if item_seminar.name.size > 1 %}
+                        <h4>Speakers</h4>
+                    {% else %}
+                        <h4>Speaker</h4>
+                    {% endif %}
+                    {% for item_names in item_seminar.name %}
+                        {% for item_name in item_names offset: 1 %}
+                            {{ item_name }}
+                        {% endfor %}
+                        {% if forloop.last %}
+                            {{ item_names[0] }}
+                        {% else %}
+                            {{ item_names[0] | append:',' }}
+                        {% endif %}
                     {% endfor %}
-                    {{ item_names[0] }}
-                    <br />
-                {% endfor %}
-                <h4>Affiliation</h4>
-                {{ item_seminar.affiliation }}
-                <h4>Abstract</h4>
-                {{ item_seminar.abstract }}
-                <h4>Bio</h4>
-                {{ item_seminar.bio }}
-                {% assign video_id = item_seminar.video %}
-                {% assign video_size = video_id.size %}
-                {% if video_size > 0 %}
-                    <h4>Video</h4>
-                    {% vimeo video_id %}
-                {% endif %}
+                    <h4>Affiliation</h4>
+                    {{ item_seminar.affiliation }}
+                </div>
+                <div class="col-md-2 col-md-pull-10">
+                    <h4>Date</h4>
+                    {{ item_seminar.date | date: '%b %d, %Y'}}
+                    <h4>Time</h4>
+                    {{ item_seminar.time }}
+                    <h4>Location</h4>
+                    {{ item_seminar.location }}
+                </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                {{ content }}
+            <div class="row">
+                <div class="col-md-6 col-md-push-2">
+                    <h4>Abstract</h4>
+                    {{ item_seminar.abstract }}
+                    <h4>Bio</h4>
+                    {{ item_seminar.bio }}
+                    {% assign video_id = item_seminar.video %}
+                    {% assign video_size = video_id.size %}
+                    {% if video_size > 0 %}
+                        <h4>Video</h4>
+                        {% vimeo video_id %}
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>
-    <!-- Content End -->
 </div>
 <!-- Main End -->
 

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -9,7 +9,6 @@ title:        "From Paid to Organic Crowdsourcing"
 
 location:     HUB 250 
 
-
 date:         2015-10-21
 
 time:         "12:00 PM"

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -9,7 +9,6 @@ title:        "Interactive and Interpretable Machine Learning Models for Human M
 
 location:     HUB 334 
 
-
 date:         2015-10-28
 
 time:         "12:00 PM"

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -9,7 +9,6 @@ title:        "Glass Fibers, Mental Models, Mobile Devices, and Electro Shocks"
 
 location:     HUB 334 
 
-
 date:         2015-11-04
 
 time:         "12:00 PM"

--- a/index.md
+++ b/index.md
@@ -82,7 +82,18 @@ title_secondary: "HCI & Design at the University of Washington"
       {% assign currentDate = site.time %}
       {% assign upcoming = site.seminars | seminar_upcoming: currentDate %}
       {% if upcoming == empty %}
-        No upcoming seminars have yet been scheduled.
+        <div class = "row">
+          <div class="col-md-12">
+            No upcoming seminars have yet been scheduled.
+          </div>
+          <div class="col-md-12"><hr /></div>
+          <div class="col-md-12">
+            <p>
+              <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+              &nbsp;&nbsp;<a href="/calendar.html">View Full Calendar</a>
+            </p>
+          </div>
+        </div>
       {% else %}
         {% for item_seminar in upcoming limit: 2 %}
           <div class = "row">
@@ -106,19 +117,18 @@ title_secondary: "HCI & Design at the University of Washington"
             </div>
           </div>
         {% endfor %}
-      </div>
-      {% endif %}
-      <div class = "row">
-        <div class="col-md-12"><hr /></div>
-        <div class="col-md-2"></div>
-        <div class="col-md-10">
-          <p>
-            <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
-            &emsp;
-            <a href="/calendar.html">View Full Calendar</a>
-          </p>
+        <div class = "row">
+          <div class="col-md-12"><hr /></div>
+          <div class="col-md-2"></div>
+          <div class="col-md-10">
+            <p>
+              <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+              &emsp;
+              <a href="/calendar.html">View Full Calendar</a>
+            </p>
+          </div>
         </div>
-      </div>
+      {% endif %}
     </section>
   </div>
   <div class="col-md-4">


### PR DESCRIPTION
- Tweaked front page seminar box (link to calendar page is left-aligned when no seminars scheduled)
- Fixed issue on calendar pages where 'location' was sometimes break-lining at the wrong spot
- Fixed issue with wrong container id in seminar layout file
- Added sidebar to seminar layout file
- Content on seminar pages now reorders itself based on window size
- Multiple speaker names are comma separated on the same line
- Removed extra spacing in some seminar collection files

Part of #108 