### PR TITLE
Update Seminar Files & Implement New TBD Behavior

### DIFF
--- a/_includes/seminartable.md
+++ b/_includes/seminartable.md
@@ -8,61 +8,60 @@
   <section>
     <div class="row">
       {% for item_seminar in seminars %}
-        {% if item_seminar.tbd %}
-          {% assign item_publish_speakers = null %}
-          {% assign item_publish_title = "TBD" %}
-        {% else %}
-          {% assign item_publish_speakers = item_seminar.speakers %}
-          {% assign item_publish_title = item_seminar.title %}
-        {% endif %}
         <div class="col-md-3">
           <div class="col-xs-12">
-            <h4>
+            <h4 class="tableheading">
               {{ item_seminar.date | date: "%m/%d/%y"}}
             </h4>
           </div>
           <div class="col-xs-12">
             {{ item_seminar.time }}&nbsp;
           </div>
-          <div class="col-xs-12">
-            {{ item_seminar.location }}
-          </div>
+          {% unless item_seminar.tbd_location %}
+            <div class="col-xs-12">
+              {{ item_seminar.location }}
+            </div>
+          {% endunless %}
         </div>
         <div class="col-md-9">
-          <div class="col-xs-12">
-            <h4>            
-              <a href="{{ item_seminar.url }}">
-                {{ item_publish_title }}
-              </a>
-            </h4>
-          </div>
-          {% assign item_affiliations = '' | split: ',' %}
-          {% if item_publish_speakers && item_publish_speakers.size > 0 %}
-            {% for item_speaker in item_publish_speakers %}
+          {% unless item_seminar.tbd_title %}
+            <div class="col-xs-12">
+              <h4 class="tableheading">            
+                <a href="{{ item_seminar.url }}">{{ item_seminar.title }}</a>
+              </h4>
+            </div>
+          {% elsif item_seminar.tbd_speakers %}
+            <div class="col-xs-12">
+              <h4 class="tableheading">DUB Seminar: Speaker TBD</h4>
+            </div>
+          {% endunless %}
+          {% unless item_seminar.tbd_speakers %}
+            {% assign item_affiliations = '' | split: ',' %}
+            {% for item_speaker in item_seminar.speakers %}
               {% assign item_affiliations = item_affiliations | push: item_speaker.affiliation | uniq %}
             {% endfor %}
-          {% endif %}
-          {% for item_affiliation in item_affiliations %}
-            {% assign item_affiliation_names = '' | split: ' ' %}
-            {% for item_speaker in item_publish_speakers %}
-              {% if item_speaker.affiliation == item_affiliation %}
-                {% assign item_full_name = '' %}
-                {% for item_name in item_speaker.name offset: 1 %}
-                  {% assign item_full_name = item_full_name | append: ' ' | append: item_name %}
-                  {% if forloop.last %}
-                    {% assign item_full_name = item_full_name | append: ' ' | append: item_speaker.name[0] %}
-                  {% endif %}
-                {% endfor %}
-                {% assign item_affiliation_names = item_affiliation_names | push: item_full_name %}
-              {% endif %}
+            {% for item_affiliation in item_affiliations %}
+              {% assign item_affiliation_names = '' | split: ' ' %}
+              {% for item_speaker in item_seminar.speakers %}
+                {% if item_speaker.affiliation == item_affiliation %}
+                  {% assign item_full_name = '' %}
+                  {% for item_name in item_speaker.name offset: 1 %}
+                    {% assign item_full_name = item_full_name | append: ' ' | append: item_name %}
+                    {% if forloop.last %}
+                      {% assign item_full_name = item_full_name | append: ' ' | append: item_speaker.name[0] %}
+                    {% endif %}
+                  {% endfor %}
+                  {% assign item_affiliation_names = item_affiliation_names | push: item_full_name %}
+                {% endif %}
+              {% endfor %}
+              <div class="col-xs-12">
+                {{ item_affiliation_names | join: ', ' }}
+              </div>
+              <div class="text-muted col-xs-12">
+                {{ item_affiliation }}
+              </div>
             {% endfor %}
-            <div class="col-xs-12">
-              {{ item_affiliation_names | join: ', ' }}
-            </div>
-            <div class="text-muted col-xs-12">
-              {{ item_affiliation }}
-            </div>
-          {% endfor %}
+          {% endunless %}
         </div>
         <div class="col-xs-12">
           <hr />

--- a/_layouts/seminar.html
+++ b/_layouts/seminar.html
@@ -34,6 +34,13 @@
                     </ul>
                 </div>
                 <div class="col-md-2 col-md-pull-4">
+                    {% if item_seminar.tbd_title %}
+                        {% if item_seminar.tbd_speakers %}
+                            {% assign item_publish_title = "DUB Seminar: Speaker TBD" %}
+                        {% endif %}
+                    {% else %}
+                        {% assign item_publish_title = item_seminar.title %}
+                    {% endif %}
                     <div class="col-xs-12">
                         <h3>Date</h3>
                         {{ item_seminar.date | date: '%b %d, %Y'}}
@@ -43,36 +50,27 @@
                         {{ item_seminar.time }}
                     </div>
                     <div class="col-xs-12">
-                        <h3>Location</h3>
-                        {{ item_seminar.location }}
+                        {% unless item_seminar.tbd_location %}
+                            <h3>Location</h3>
+                            {{ item_seminar.location }}
+                        {% endunless %}
                     </div>
                 </div>
                 <div class="col-md-6 col-md-pull-4">
-                    {% if item_seminar.tbd %}
-                        {% assign item_publish_speakers = null %}
-                        {% assign item_publish_title = "TBD" %}
-                        {% assign item_publish_abstract = null %}
-                        {% assign item_publish_bio = null %}
-                        {% assign item_publish_video = null %}
-                    {% else %}
-                        {% assign item_publish_speakers = item_seminar.speakers %}
-                        {% assign item_publish_title = item_seminar.title %}
-                        {% assign item_publish_abstract = item_seminar.abstract %}
-                        {% assign item_publish_bio = item_seminar.bio %}
-                        {% assign item_publish_video = item_seminar.video %}
-                    {% endif %}
                     <div class="col-xs-12">
-                        <h3>Title</h3>
-                        {{ item_publish_title }}
+                        {% unless item_seminar.tbd_title %}
+                            <h3>Title</h3>
+                            {{ item_publish_title }}
+                        {% endunless %}
                     </div>
                     <div class="col-xs-12">
-                        {% if item_publish_speakers %}
-                            {% if item_publish_speakers.size > 1 %}
+                        {% unless item_seminar.tbd_speakers %}
+                            {% if item_seminar.speakers.size > 1 %}
                                 <h3>Speakers</h3>
                             {% else %}
                                 <h3>Speaker</h3>
                             {% endif %}
-                            {% if item_publish_speakers.size > 0 %}
+                            {% if item_seminar.speakers.size > 0 %}
                                 {% assign item_affiliations = '' | split: ',' %}
                                 {% for item_speaker in item_seminar.speakers %}
                                     {% assign item_affiliations = item_affiliations | push: item_speaker.affiliation | uniq %}
@@ -99,27 +97,27 @@
                                     {{ item_affiliation }}
                                 </div>
                             {% endfor %}
-                        {% endif %}
+                        {% endunless %}
                     </div>
                     <div class="col-xs-12">
-                        {% if item_publish_abstract.size > 0 %}
+                        {% unless item_seminar.tbd_abstract %}
                             <h3>Abstract</h3>
-                            {{ item_publish_abstract | markdownify }}
-                        {% endif %}
+                            {{ item_seminar.abstract | markdownify }}
+                        {% endunless %}
                     </div>
                     <div class="col-xs-12">
-                        {% if item_publish_bio.size > 0 %}
+                        {% unless item_seminar.tbd_bio %}
                             <h3>Bio</h3>
-                            {{ item_publish_bio | markdownify }}
-                        {% endif %}
+                            {{ item_seminar.bio | markdownify }}
+                        {% endunless %}
                     </div>
                     <div class="col-xs-12">
-                        {% if item_publish_video.size > 0 %}
+                        {% unless item_seminar.tbd_video %}
                             <h3>Video</h3>
                             <div class='embed-container'>
-                                {% vimeo item_publish_video %}
+                                {% vimeo item_seminar.video %}
                             </div>
-                        {% endif %}
+                        {% endunless %}
                     </div>
                 </div>
             </div>

--- a/_seminars/2015-10-07.md
+++ b/_seminars/2015-10-07.md
@@ -14,6 +14,11 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +35,9 @@ speakers:
     - Luz
     affiliation:  Carnegie Mellon University
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "ChangeDyslexia: Early Detection and Intervention at Large Scale"
 
 location:     HUB 145
@@ -55,7 +63,14 @@ bio: |
   NLP. Her IDEAL eBook reader and Dyseggxia game (Vodafone Foundation Mobile for Good Europe Awards 2013) have received 
   nearly one hundred thousand downloads in more than 70 countries. Currently, she is working to detect dyslexia at 
   large scale and on bringing this work to society via her non-profit organization Change Dyslexia.
-
+  
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 video:        142303577
 
 ---

--- a/_seminars/2015-10-14.md
+++ b/_seminars/2015-10-14.md
@@ -14,6 +14,12 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+tbd_video:      True
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +36,9 @@ speakers:
     - Adam
     affiliation:  Microsoft Research
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Leveraging Signals Generated From Search Engines and Web-based Resources"
 
 location:     HUB 334
@@ -56,5 +65,13 @@ bio: |
   University of Waterloo, a bachelor's degree from the University of Ottawa, and has interned on two occasions at 
   Microsoft Research Redmond. Outside of his primary research interests, Adam is an active developer in the Pebble 
   smartwatch community.
+
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 
 ---

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -14,6 +14,12 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+tbd_video:      True
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +36,9 @@ speakers:
     - Krzysztof
     affiliation:  Harvard University
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "From Paid to Organic Crowdsourcing"
 
 location:     HUB 250 
@@ -67,5 +76,13 @@ bio: |
   faculty at the Ashesi University in Accra, Ghana, where he taught Introduction to Artificial Intelligence. Krzysztof 
   is a coeditor-in-chief of the ACM Transactions on Interactive Intelligent Systems. He is a recipient of a Sloan 
   Research Fellowship.
+  
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 
 ---

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -14,6 +14,11 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +35,9 @@ speakers:
     - Been
     affiliation:  Computer Science & Engineering
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Interactive and Interpretable Machine Learning Models for Human Machine Collaboration"
 
 location:     HUB 334 
@@ -59,7 +67,14 @@ bio: |
   Engineering at the University of Washington. Her research focuses on interactive and interpretable machine learning 
   models for human-machine collaboration. She received her PhD. from MIT. Prior to her PhD, she worked at the MathWorks 
   as a software engineer.
-
+  
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 video:        144178224
 
 ---

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -14,6 +14,12 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+tbd_video:      True
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +36,9 @@ speakers:
     - Christian
     affiliation:  Microsoft Research
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Glass Fibers, Mental Models, Mobile Devices, and Electro Shocks"
 
 location:     HUB 334 
@@ -55,5 +64,13 @@ bio: |
   Germany and his work has received honorable mentions at ACM CHI and a best paper award at ACM UIST. Christian holds a 
   Ph.D. in Human-Computer Interaction and masters and bachelor degrees in Software Engineering from University of 
   Potsdam, Germany. 
-  
+
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
+
 ---

--- a/_seminars/2015-11-18.md
+++ b/_seminars/2015-11-18.md
@@ -14,6 +14,12 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+tbd_video:      True
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +36,9 @@ speakers:
     - Jeffrey
     affiliation:  Riot Games
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "67 million trials in 4 weeks: How online video games can change how we think about research, and how research can change how we design video games"
 
 location:     HUB 250
@@ -62,5 +71,13 @@ bio: |
   learnings into viable game features that enhance engagement while amplifying the sportsmanlike behavior that already 
   exists in the community. Before Riot, Jeffrey was an experimental psychologist at Valve Software and received his 
   Ph.D. in cognitive neuroscience from the University of Washington with Dr. Geoffrey Boynton and Dr. Scott Murray.  
+
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 
 ---

--- a/_seminars/2015-11-25.md
+++ b/_seminars/2015-11-25.md
@@ -14,6 +14,11 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +35,9 @@ speakers:
     - Katharina
     affiliation:  Computer Science & Engineering
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Using Large-Scale Online Experiments to Design less WEIRD User Interfaces"
 
 location:     HUB 334 
@@ -62,6 +70,13 @@ bio: |
   at premier venues in human-computer interaction (ACM CHI, ACM CSCW, UMAP), a Google Research Faculty award, as well
   as the Mercator Prize for the best doctoral thesis at the University of Zurich in 2011.  
 
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 video:        147393794
 
 ---

--- a/_seminars/2015-12-02.md
+++ b/_seminars/2015-12-02.md
@@ -14,6 +14,11 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -42,6 +47,9 @@ speakers:
     - Emma
     affiliation: University of Washington, Tacoma
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Building up STE(A)M: The UCD Charrette for K-12 Outreach"
 
 location:     HUB 334
@@ -64,7 +72,14 @@ abstract: |
 bio: |
   Andrew Davidson is a HCDE Senior Lecturer and former high school teacher, and Elena Agapie and Kiley Sobel are HCDE PhD 
   students. Emma Rose is a UWT Assistant Professor.
-  
+
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
 video:        151061389
 
 ---

--- a/_seminars/2015-12-09.md
+++ b/_seminars/2015-12-09.md
@@ -14,6 +14,12 @@ time:         "12:00 PM"
 time_end:     "1:20 PM"
 
 ################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+tbd_video:      True
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:
@@ -30,6 +36,9 @@ speakers:
     - Sue
     affiliation:  Cornell University
 
+################################################################################
+# Our core fields are title, location, abstract, bio.
+################################################################################
 title:        "Understanding and Supporting Communication Across Linguistic Boundaries"
 
 location:     HUB 332
@@ -60,4 +69,12 @@ bio: |
   to motivate people to reduce their energy usage.  More information can be found on her website 
   <http://sfussell.hci.cornell.edu> or her lab Facebook page <https://www.facebook.com/InterculturalCommLab>.
   
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
+
 ---

--- a/_seminars/2016-01-06.md
+++ b/_seminars/2016-01-06.md
@@ -14,9 +14,13 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_speakers:   True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-01-13.md
+++ b/_seminars/2016-01-13.md
@@ -14,9 +14,10 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-01-20.md
+++ b/_seminars/2016-01-20.md
@@ -14,10 +14,14 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
-tbd: True
+tbd_speakers:   True
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-01-27.md
+++ b/_seminars/2016-01-27.md
@@ -14,9 +14,10 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.
@@ -42,14 +43,23 @@ speakers:
 ################################################################################
 # Our core fields are title, location, abstract, bio.
 ################################################################################
-title:    "TBD"
+title:    "Reading Between the Lines: Improving Comprehension for Students"
 
 location: HUB 334
 
 abstract: |
-
+    While reading is arguably a student's most important skill, the technology of reading is relatively unchanged. 
+    Can the power of computing improve a student's reading comprehension? We will discuss what has been learned about 
+    typography in the last 500 years, about reading psychology in the last 100 years, and what technology can be 
+    invented right now.
+    
 bio: |
-
+    Mike Bennett and Kevin Larson are teammates on Microsoft's Advanced Reading Technologies team. For over 25 years 
+    the team has been researching how to make on-screen reading better. Mike is a vision scientist, who did a postdoc 
+    in Stanford University, was a researcher in MIT's Media Lab Europe, and holds a PhD from University College Dublin, 
+    Ireland. Kevin is a reading psychologist with a PhD from the University of Texas; he is well-known in the field of 
+    typography for bridging the knowledge gap between design and the science of reading.
+ 
 ################################################################################
 # A seminar may have a video. If so, provide the Vimeo video number.
 #

--- a/_seminars/2016-02-03.md
+++ b/_seminars/2016-02-03.md
@@ -14,9 +14,13 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-02-10.md
+++ b/_seminars/2016-02-10.md
@@ -14,9 +14,13 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-02-17.md
+++ b/_seminars/2016-02-17.md
@@ -14,9 +14,13 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_title:      True
+tbd_abstract:   Trues
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-02-24.md
+++ b/_seminars/2016-02-24.md
@@ -14,9 +14,13 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-03-02.md
+++ b/_seminars/2016-03-02.md
@@ -14,10 +14,14 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
-tbd: True
+tbd_speakers:   True
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-03-09.md
+++ b/_seminars/2016-03-09.md
@@ -14,10 +14,14 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
-tbd: True
+tbd_speakers:   True
+tbd_title:      True
+tbd_abstract:   True
+tbd_bio:        True
+tbd_video:      True
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/_template.md
+++ b/_seminars/_template.md
@@ -14,8 +14,8 @@ time:     "12:00 PM"
 time_end: "1:20 PM"
 
 ################################################################################
-# A seminar file might exist but not yet be scheduled. This is 'TBD'. 
-# The only valid value is 'True'. The field should not be present if 'False'.
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
 ################################################################################
 tbd_speakers:   True
 tbd_title:      True

--- a/css/styles.less
+++ b/css/styles.less
@@ -58,8 +58,14 @@
 }
 
 // Front page date left-aligns for md and smaller screen size
-@media (max-width: @screen-md-min) {
+@media (max-width: @screen-md-min){
     .xs-left {
         text-align: left;
     }
+}
+
+// Seminar table header text aligns with normal text
+.tableheading
+{
+    display: inline;
 }

--- a/index.md
+++ b/index.md
@@ -98,20 +98,38 @@ design, people, and technology.
       {% assign upcoming = site.seminars | seminar_upcoming: site.time %}
       {% for item_seminar in upcoming limit: 3 %}
         <div class="row upcomingseminar">
-          {% if item_seminar.tbd %}
-              {% assign item_publish_title = "TBD" %}
-           {% else %}
-              {% assign item_publish_title = item_seminar.title %}
-           {% endif %}
           <div class="col-xs-4">
             <strong>{{ item_seminar.date | date: "%b %-d" | upcase }}</strong>
           </div>
           <div class="col-xs-8 text-right">
-            {{ item_seminar.location }}
+            {% unless item_seminar.tbd_location %}
+              {{ item_seminar.location }}
+            {% endunless %}
             {{ item_seminar.time }}
           </div>
           <div class="col-xs-12">
-            <strong><a href="{{ site.baseurl }}{{ item_seminar.url }}">{{ item_publish_title }}</a></strong>
+            <strong>
+            {% unless item_seminar.tbd_title %}
+              <a href="{{ site.baseurl }}{{ item_seminar.url }}">{{ item_seminar.title }}</a>
+            {% elsif item_seminar.tbd_speakers %}
+              DUB Seminar: Speaker TBD
+            {% else %}
+              {% assign speaker_names = '' | split: ' ' %}
+              {% for item_speaker in item_seminar.speakers %}
+                {% assign item_full_name = '' %}
+                {% for item_name in item_speaker.name offset: 1 %}
+                  {% assign item_full_name = item_full_name | append: ' ' | append: item_name %}
+                  {% if forloop.last %}
+                    {% assign item_full_name = item_full_name | append: ' ' | append: item_speaker.name[0] %}
+                  {% endif %}
+                {% endfor %}
+                {% assign speaker_names = speaker_names | push: item_full_name %}
+              {% endfor %}
+              {% assign speaker_names = speaker_names | join: ', ' %}
+              {% assign speaker_title = 'DUB Seminar: ' | append: speaker_names %}
+              {{ speaker_title }}
+            {% endunless %}
+            </strong>
           </div>
         </div>
       {% endfor %}


### PR DESCRIPTION
All seminar files now use the new TBD fields. The other files have been adjusted accordingly to work with this new file structure. In addition...

For the front page:
- If there is no title or speakers assigned, 'DUB Seminar: Speaker TBD' will be displayed.
- If there is no title, but speaker(s) are assigned, 'DUB Seminar: (speaker name(s))' will be displayed.
- If location is TBD, it will not be displayed.

For the calendar page:
- If there is no title or speakers assigned, 'DUB Seminar: Speaker TBD' will be displayed as a title with no link.
- If there is no title but speaker(s) are assigned, no title will be displayed, but the speaker(s) will be displayed.
- If location is TBD, it will not be displayed

For the seminar page:
- If there is no title or speakers assigned, this page will not be linked to.
- Any field that is TBD (except for date, time) will not be displayed.

#151