### PR TITLE
Update Video for HTTPS

### DIFF
--- a/_plugins/vimeo.rb
+++ b/_plugins/vimeo.rb
@@ -26,7 +26,7 @@ module Jekyll
         @idvalue = look_up(context, $1)
       end
 
-      %(<iframe width="#{@@width}" height="#{@@height}" src="http://player.vimeo.com/video/#{@idvalue}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>)
+      %(<iframe width="#{@@width}" height="#{@@height}" src="https://player.vimeo.com/video/#{@idvalue}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>)
     end
   end
 end


### PR DESCRIPTION
Updated Vimeo embed link to work with HTTPS.

Resolves #177