### PR TITLE
Add Seminar Sequence Number And Tests

### DIFF
--- a/_seminars/2015-10-07.md
+++ b/_seminars/2015-10-07.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-10-14.md
+++ b/_seminars/2015-10-14.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-11-18.md
+++ b/_seminars/2015-11-18.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-11-25.md
+++ b/_seminars/2015-11-25.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-12-02.md
+++ b/_seminars/2015-12-02.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2015-12-09.md
+++ b/_seminars/2015-12-09.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2016-01-06.md
+++ b/_seminars/2016-01-06.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-01-13.md
+++ b/_seminars/2016-01-13.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-01-20.md
+++ b/_seminars/2016-01-20.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-01-27.md
+++ b/_seminars/2016-01-27.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-02-03.md
+++ b/_seminars/2016-02-03.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-02-10.md
+++ b/_seminars/2016-02-10.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-02-17.md
+++ b/_seminars/2016-02-17.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-02-24.md
+++ b/_seminars/2016-02-24.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-03-02.md
+++ b/_seminars/2016-03-02.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-03-09.md
+++ b/_seminars/2016-03-09.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-03-16.md
+++ b/_seminars/2016-03-16.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-03-23.md
+++ b/_seminars/2016-03-23.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-03-30.md
+++ b/_seminars/2016-03-30.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-04-06.md
+++ b/_seminars/2016-04-06.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-04-13.md
+++ b/_seminars/2016-04-13.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-04-20.md
+++ b/_seminars/2016-04-20.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-04-27.md
+++ b/_seminars/2016-04-27.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-05-04.md
+++ b/_seminars/2016-05-04.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-05-11.md
+++ b/_seminars/2016-05-11.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-05-18.md
+++ b/_seminars/2016-05-18.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-05-25.md
+++ b/_seminars/2016-05-25.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-06-01.md
+++ b/_seminars/2016-06-01.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/_seminars/2016-06-08.md
+++ b/_seminars/2016-06-08.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/2016-06-15.md
+++ b/_seminars/2016-06-15.md
@@ -6,6 +6,12 @@
 version: 1
 
 ################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 1
+
+################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.
 # Date must equal the name of this file.
 ################################################################################

--- a/_seminars/_template.md
+++ b/_seminars/_template.md
@@ -1,9 +1,15 @@
 ---
 ################################################################################
-# Version of the seminar format. The only valid value for this is 1. 
+# Version of the seminar format. The only valid value for this is '1'. 
 # We may increment this in the future to simplify maintenance of old seminars.
 ################################################################################
 version: 1
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: 0
 
 ################################################################################
 # Date and time of the seminar. In quotes because : is a reserved character.

--- a/calendar.ics
+++ b/calendar.ics
@@ -16,7 +16,7 @@ DTSTART:{{ item_seminar.date | date: "%Y%m%d" }}T{{ item_seminar.time | convert_
 DTEND:{{ item_seminar.date | date: "%Y%m%d" }}T{{ item_seminar.time_end | convert_time }}
 DTSTAMP:{{ site.time | date: "%Y%m%d" }}T{{ site.time | date: "%H%M%S" }}
 DESCRIPTION:{% include icaldescription.md %}
-SEQUENCE:0
+SEQUENCE:{{ item_seminar.sequence }}
 END:VEVENT{% unless forloop.last %}
 {{}}{% endunless %}{% endfor %}
 END:VCALENDAR

--- a/tests/test_seminars.py
+++ b/tests/test_seminars.py
@@ -56,6 +56,14 @@ class TestSeminars(unittest.TestCase):
                 'Invalid version in {}'.format(seminar_path_current)
             )
 
+            # The sequence is not 0, unless we're looking at the _template.md
+            if os.path.normpath(seminar_path_current) != os.path.normpath('_seminars/_template.md'):
+                self.assertGreater(
+                    seminar['sequence'],
+                    0,
+                    'Sequence was not incremented in {}'.format(seminar_path_current)
+                )
+
             # It has date and time fields
             self.assertIn(
                 'date',


### PR DESCRIPTION
- Added seminar sequence number to files. 

- Currently in the template file the sequence is 0, in all other files the sequence is 1

- Updated calendar.ics to pull in the sequence number

- Added test to ensure all non-template seminar files have a sequence number greater than 0.