### PR TITLE
Add Seminar Archive Property

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ defaults:
       type: seminars
     values:
       layout: seminar
+      archive: true
 
 future: true
 

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -14,7 +14,8 @@ module Jekyll
     end
 
     def seminar_previous(seminars, date)
-      seminars.select { |seminar| item_property(seminar, "date").to_date() < date.to_date() }
+      seminars.select { |seminar| item_property(seminar, "date").to_date() < date.to_date() &&
+          item_property(seminar, "archive") == true }
     end
   end
 

--- a/_seminars/2015-10-07.md
+++ b/_seminars/2015-10-07.md
@@ -19,6 +19,13 @@ time_end:     "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-10-14.md
+++ b/_seminars/2015-10-14.md
@@ -20,6 +20,13 @@ time_end:     "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-10-21.md
+++ b/_seminars/2015-10-21.md
@@ -20,6 +20,13 @@ time_end:     "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-10-28.md
+++ b/_seminars/2015-10-28.md
@@ -19,6 +19,13 @@ time_end:     "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-11-04.md
+++ b/_seminars/2015-11-04.md
@@ -20,6 +20,13 @@ time_end:     "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-11-18.md
+++ b/_seminars/2015-11-18.md
@@ -20,6 +20,13 @@ time_end:     "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-11-25.md
+++ b/_seminars/2015-11-25.md
@@ -19,6 +19,13 @@ time_end:     "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-12-02.md
+++ b/_seminars/2015-12-02.md
@@ -19,6 +19,13 @@ time_end:     "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2015-12-09.md
+++ b/_seminars/2015-12-09.md
@@ -20,6 +20,13 @@ time_end:     "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-01-06.md
+++ b/_seminars/2016-01-06.md
@@ -23,6 +23,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-01-13.md
+++ b/_seminars/2016-01-13.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-01-20.md
+++ b/_seminars/2016-01-20.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-01-27.md
+++ b/_seminars/2016-01-27.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-02-03.md
+++ b/_seminars/2016-02-03.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-02-10.md
+++ b/_seminars/2016-02-10.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-02-17.md
+++ b/_seminars/2016-02-17.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-02-24.md
+++ b/_seminars/2016-02-24.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-03-02.md
+++ b/_seminars/2016-03-02.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-03-09.md
+++ b/_seminars/2016-03-09.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-03-16.md
+++ b/_seminars/2016-03-16.md
@@ -24,6 +24,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-03-23.md
+++ b/_seminars/2016-03-23.md
@@ -24,6 +24,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-03-30.md
+++ b/_seminars/2016-03-30.md
@@ -23,6 +23,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-04-06.md
+++ b/_seminars/2016-04-06.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-04-13.md
+++ b/_seminars/2016-04-13.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-04-20.md
+++ b/_seminars/2016-04-20.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-04-27.md
+++ b/_seminars/2016-04-27.md
@@ -19,6 +19,13 @@ time_end: "1:20 PM"
 ################################################################################
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-05-04.md
+++ b/_seminars/2016-05-04.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-05-11.md
+++ b/_seminars/2016-05-11.md
@@ -24,6 +24,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-05-18.md
+++ b/_seminars/2016-05-18.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-05-25.md
+++ b/_seminars/2016-05-25.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-06-01.md
+++ b/_seminars/2016-06-01.md
@@ -20,6 +20,13 @@ time_end: "1:20 PM"
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-06-08.md
+++ b/_seminars/2016-06-08.md
@@ -24,6 +24,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/2016-06-15.md
+++ b/_seminars/2016-06-15.md
@@ -24,6 +24,14 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+archive: false
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # speakers:

--- a/_seminars/_template.md
+++ b/_seminars/_template.md
@@ -25,6 +25,13 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
+# Seminar files are archived by default.
+# Add the following line if the file should not be archived:
+#
+# archive: false
+################################################################################
+
+################################################################################
 # One or more speakers. Each speaker has name and affiliation.
 #
 # If a speaker does not have an affiliation, the affiliation field can be removed.


### PR DESCRIPTION
- Seminars that are to be archived will show up under 'Previous Seminars'. Seminars that are not to be archived are things like Faculty Meeting, Quarter Break, and CHI.

- The default value of archive is true. The value should explicitly be set to false if seminar item is not to be archived.

- The 'previous' filter has been modified to filter out seminar items that have archive value set to false.