### PR TITLE
Add no_dub_seminar and Modify for Consistency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,6 @@ defaults:
       type: seminars
     values:
       layout: seminar
-      archive: true
 
 future: true
 

--- a/_includes/seminartable.md
+++ b/_includes/seminartable.md
@@ -15,9 +15,11 @@
             </h4>
           </div>
           {% if include.seminars == "upcoming" %}
-            <div class="col-xs-12">
-              {{ item_seminar.time }}
-            </div>
+            {% unless item_seminar.no_dub_seminar == true %}
+              <div class="col-xs-12">
+                {{ item_seminar.time }}
+              </div>
+            {% endunless %}
             {% unless item_seminar.tbd_location %}
               <div class="col-xs-12">
                 {{ item_seminar.location }}
@@ -28,9 +30,15 @@
         <div class="col-md-9">
           {% unless item_seminar.tbd_title %}
             <div class="col-xs-12">
-              <h4 class="tableheading">            
-                <a href="{{ item_seminar.url }}">{{ item_seminar.title }}</a>
-              </h4>
+              {% if item_seminar.no_dub_seminar == true %}
+                <div class="tableheading text-muted no-seminar">
+                  {{ item_seminar.title }}
+                </div>
+              {% else %}
+                <h4 class="tableheading">
+                  <a href="{{ item_seminar.url }}">{{ item_seminar.title }}</a>
+                </h4>
+              {% endif %}
             </div>
           {% else %}
             <div class="col-xs-12">

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -15,7 +15,7 @@ module Jekyll
 
     def seminar_previous(seminars, date)
       seminars.select { |seminar| item_property(seminar, "date").to_date() < date.to_date() &&
-          item_property(seminar, "archive") == true }
+          item_property(seminar, "no_archive") != true }
     end
   end
 

--- a/_seminars/2016-01-06.md
+++ b/_seminars/2016-01-06.md
@@ -29,12 +29,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-03-16.md
+++ b/_seminars/2016-03-16.md
@@ -30,12 +30,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-03-23.md
+++ b/_seminars/2016-03-23.md
@@ -30,12 +30,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-03-30.md
+++ b/_seminars/2016-03-30.md
@@ -29,12 +29,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-05-11.md
+++ b/_seminars/2016-05-11.md
@@ -30,12 +30,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-06-08.md
+++ b/_seminars/2016-06-08.md
@@ -30,12 +30,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-06-15.md
+++ b/_seminars/2016-06-15.md
@@ -30,12 +30,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-08-24.md
+++ b/_seminars/2016-08-24.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-08-31.md
+++ b/_seminars/2016-08-31.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-09-07.md
+++ b/_seminars/2016-09-07.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-09-14.md
+++ b/_seminars/2016-09-14.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-09-21.md
+++ b/_seminars/2016-09-21.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-09-28.md
+++ b/_seminars/2016-09-28.md
@@ -29,12 +29,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-12-14.md
+++ b/_seminars/2016-12-14.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-12-21.md
+++ b/_seminars/2016-12-21.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2016-12-28.md
+++ b/_seminars/2016-12-28.md
@@ -30,12 +30,16 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_dub_seminar: true
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2017-01-04.md
+++ b/_seminars/2017-01-04.md
@@ -29,12 +29,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/2017-03-29.md
+++ b/_seminars/2017-03-29.md
@@ -29,12 +29,15 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
-archive: false
+no_archive: true
 
 ################################################################################
 # One or more speakers. Each speaker has name and affiliation.

--- a/_seminars/_template.md
+++ b/_seminars/_template.md
@@ -31,10 +31,13 @@ tbd_bio:        true
 tbd_video:      true
 
 ################################################################################
-# Seminar files are archived by default.
-# Add the following line if the file should not be archived:
+# If a date is "No DUB Seminar", we display it differently.
 #
-# archive: false
+# no_dub_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
 ################################################################################
 
 ################################################################################

--- a/css/styles.less
+++ b/css/styles.less
@@ -93,6 +93,10 @@
     display: inline;
 }
 
+.no-seminar{
+    font-style: italic;
+}
+
 .vimeo-icon
 {
     height: 16px;

--- a/tests/test_seminars.py
+++ b/tests/test_seminars.py
@@ -94,6 +94,18 @@ class TestSeminars(unittest.TestCase):
                     'Date does not match filename in {}'.format(seminar_path_current)
                 )
 
+            # If a seminar is no_dub_seminar, it should also be no_archive.
+            if 'no_dub_seminar' in seminar:
+                # If the field exists, its value must be True
+                self.assertTrue(
+                    seminar['no_dub_seminar'],
+                    'Invalid no_dub_seminar in {}'.format(seminar_path_current)
+                )
+                self.assertTrue(
+                    seminar['no_archive'],
+                    'Invalid no_archive in {}'.format(seminar_path_current)
+                )
+
             # The speaker may be tbd
             if 'tbd_speakers' in seminar:
                 # If the field exists, its value must be True


### PR DESCRIPTION
- Added no_dub_seminar. Set no_dub_seminar for applicable upcoming seminars. Changed the font for no_dub_seminar (smaller, grey, italic)

- Changed archive value to no_archive. This removes the need to have a default set.

- Added a test. If a seminar is no_dub_seminar, it should also be no_archive.

Closes #291 