### PR TITLE
Subscription link

### DIFF
--- a/calendar.md
+++ b/calendar.md
@@ -9,7 +9,12 @@ title_bar_secondary: "HCI & Design at the University of Washington"
 <ul id="seminar-tabs" class="nav nav-pills nav-stacked" data-tabs="tabs">
   <li class="active"><a href="#upcoming_seminars" data-toggle="tab">Upcoming Seminars</a></li>
   <li><a href="#previous_seminars" data-toggle="tab">Previous Seminars</a></li>
-  <li>Subscription link: <a href="http://www.google.com/calendar/render?cid=http://{{ site.baseurl }}/calendar.ics">Google</a> <a href="webcal://{{ site.baseurl }}/calendar.ics">Microsoft/Apple</a></li>
+</ul>
+
+<h4>Calendar Subscriptions</h4>
+<ul class="nav nav-pills nav-stacked">
+    <li><a href="http://www.google.com/calendar/render?cid=http://{{ site.baseurl }}/calendar.ics">Google Calendar</a></li>
+    <li><a href="webcal://{{ site.baseurl }}/calendar.ics">iCal / Webcal</a></li>
 </ul>
 
 <div class="sidebar_end"></div>

--- a/calendar.md
+++ b/calendar.md
@@ -9,6 +9,7 @@ title_bar_secondary: "HCI & Design at the University of Washington"
 <ul id="seminar-tabs" class="nav nav-pills nav-stacked" data-tabs="tabs">
   <li class="active"><a href="#upcoming_seminars" data-toggle="tab">Upcoming Seminars</a></li>
   <li><a href="#previous_seminars" data-toggle="tab">Previous Seminars</a></li>
+  <li>Subscription link: <a href="calendar.ics">{{ site.baseurl }}/calendar.ics</a></li>
 </ul>
 
 <div class="sidebar_end"></div>

--- a/calendar.md
+++ b/calendar.md
@@ -9,7 +9,7 @@ title_bar_secondary: "HCI & Design at the University of Washington"
 <ul id="seminar-tabs" class="nav nav-pills nav-stacked" data-tabs="tabs">
   <li class="active"><a href="#upcoming_seminars" data-toggle="tab">Upcoming Seminars</a></li>
   <li><a href="#previous_seminars" data-toggle="tab">Previous Seminars</a></li>
-  <li>Subscription link: <a href="calendar.ics">{{ site.baseurl }}/calendar.ics</a></li>
+  <li>Subscription link: <a href="http://www.google.com/calendar/render?cid=http://{{ site.baseurl }}/calendar.ics">Google</a> <a href="webcal://{{ site.baseurl }}/calendar.ics">Microsoft/Apple</a></li>
 </ul>
 
 <div class="sidebar_end"></div>


### PR DESCRIPTION
#257
`webcal://` works for outlook & apple calendar app, but not Google. The
Google subscribe link no longer seems to work. This got me closer, but
I still got an error:
http://stackoverflow.com/questions/12563178/link-to-add-ics-to-google-ca
lendar-stopped-working

So this PR is the catch-all of a link to the file and the URL in text.
People can copy either the string or the link address into their
calendar app.