### PR TITLE
Adding DOI links to CSCW page. Note -- need to test before integrating. 

### DIFF
--- a/_posts/2017-01-17-cscw2017papers.md
+++ b/_posts/2017-01-17-cscw2017papers.md
@@ -17,6 +17,7 @@ papers:
   hm: true
   title: 'AACrobat: Using Mobile Devices to Lower Communication Barriers and Provide
     Autonomy With Gaze-Based AAC'
+  doiurl: https://doi.org/10.1145/2998181.2998215
 - authors:
   - affiliation: UW Information School
     name: Jordan Eschler
@@ -26,6 +27,7 @@ papers:
   hm: true
   title: '"I''m So Glad I Met You": Designing Dynamic Collaborative Support for Young
     Adult Cancer Survivors'
+  doiurl: https://doi.org/10.1145/2998181.2998326
 - authors:
   - affiliation: UW Information School
     name: Norah Abokhodair
@@ -37,6 +39,7 @@ papers:
   hm: true
   title: 'Photo Sharing in the Arab Gulf:  Expressing the Collective and Autonomous
     Selves'
+  doiurl: https://doi.org/10.1145/2998181.2998338
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: Dharma Dailey
@@ -46,6 +49,7 @@ papers:
   hm: true
   title: 'Social Media Seamsters: Stitching Platforms & Audiences Into Local Crisis
     Infrastructure'
+  doiurl: https://doi.org/10.1145/2998181.2998290
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: Ahmer Arif
@@ -65,6 +69,7 @@ papers:
   hm: false
   title: 'A Closer Look at the Self-Correcting Crowd: Examining Corrections in Online
     Rumors'
+  doiurl: https://doi.org/10.1145/2998181.2998294
 - authors:
   - affiliation: UW Information School
     name: Kathleen O'Leary
@@ -79,6 +84,7 @@ papers:
   award: false
   hm: false
   title: Design Opportunities for Mental Health Peer Support Technologies
+  doiurl: https://doi.org/10.1145/2998181.2998349
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: Kerem Ozcan
@@ -91,6 +97,7 @@ papers:
   award: false
   hm: false
   title: 'Designing for Targeted Responder Models: Exploring Barriers to Respond'
+  doiurl: https://doi.org/10.1145/2998181.2998334
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: Kiley Sobel
@@ -111,6 +118,7 @@ papers:
   award: false
   hm: false
   title: 'EduFeed: A Social Feed to Engage Preliterate Children in Educational Activities'
+  doiurl: https://doi.org/10.1145/2998181.2998231
 - authors:
   - affiliation: UW Computer Science & Engineering / UW Human Centered Design & Engineering
     name: Laura R Pina
@@ -130,6 +138,7 @@ papers:
   hm: false
   title: 'From Personal Informatics to Family Informatics:  Understanding Family Practices
     Around Health Monitoring'
+  doiurl: https://doi.org/10.1145/2998181.2998362
 - authors:
   - affiliation: UW Educational Psychology
     name: Sarah Evans
@@ -149,6 +158,7 @@ papers:
   hm: false
   title: 'More Than Peer Production: Fanfiction Communities as Sites of Distributed
     Mentoring'
+  doiurl: https://doi.org/10.1145/2998181.2998342
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: David Ribes
@@ -156,6 +166,7 @@ papers:
   hm: false
   title: 'Notes on the Concept of Data Interoperability: Cases From an Ecology of
     AIDS Research Infrastructures'
+  doiurl: https://doi.org/10.1145/2998181.2998344
 - authors:
   - affiliation: UW Human Centered Design & Engineering
     name: Rafal Kocielnik
@@ -165,6 +176,7 @@ papers:
   hm: false
   title: 'Send Me a Different Message: Utilizing Cognitive Space to Create Engaging
     Message Triggers'
+  doiurl: https://doi.org/10.1145/2998181.2998324
 - authors:
   - affiliation: UW Computer Science & Engineering
     name: Jessica Schroeder
@@ -182,6 +194,7 @@ papers:
   hm: false
   title: Supporting Patient-Provider Collaboration to Identify Individual Triggers
     Using Food and Symptom Journals
+  doiurl: https://doi.org/10.1145/2998181.2998276
 - authors:
   - affiliation: University of Southern California
     name: Alex Leavitt
@@ -191,6 +204,7 @@ papers:
   hm: false
   title: 'The Role of Information Visibility in Network Gatekeeping: Information Aggregation
     on Reddit During Crisis Events'
+  doiurl: https://doi.org/10.1145/2998181.2998299
 - authors:
   - affiliation: Northwestern University
     name: Sneha Narayan
@@ -206,12 +220,14 @@ papers:
   hm: false
   title: 'The Wikipedia Adventure: Field Evaluation of an Interactive Tutorial for
     New Users'
+  doiurl: https://doi.org/10.1145/2998181.2998307
 - authors:
   - affiliation: UW Information School
     name: Jaime Snyder
   award: false
   hm: false
   title: Vernacular Visualization Practices in a Citizen Science Project
+  doiurl: https://doi.org/10.1145/2998181.2998239
 - authors:
   - affiliation: UW Information School
     name: Amanda Menking
@@ -223,7 +239,8 @@ papers:
   hm: false
   title: 'Who Wants to Read This?: A Method for Measuring Topical Representativeness
     in User Generated Content Systems'
-
+  doiurl: https://doi.org/10.1145/2998181.2998254
+  
 ---
 
 <div class="row" style="margin-bottom: 15px">
@@ -250,7 +267,11 @@ Join us at CSCW 2017 in Portland!
 <div class="row" style="margin-bottom: 15px">
   <div class="col-xs-12">
     <h4>
+      {% if paper_current.doiurl %}
+      <a href="{{ paper_current.doiurl }}">{{ paper_current.title }}</a>
+      {% else %}
       {{ paper_current.title }}
+      {% endif %}
     </h4>
   </div>
   {% if paper_current.award or paper_current.hm %}


### PR DESCRIPTION
James,

a) tested a script that can read the ACM TOC page (e.g., http://dl.acm.org/citation.cfm?id=2998181&CFID=902754499&CFTOKEN=19384773) to find DOI links. Looks like it worked to populate data. 
b) For now, added those links to titles
c) Bad news -- something is off with my ability to test this locally, so *please test before integrating into live site.*
d) fixed for a typo I made in the template

sean