### PR TITLE
In progress: Add seminar file parser and renderer

### DIFF
--- a/_seminars/_template.j2
+++ b/_seminars/_template.j2
@@ -1,0 +1,131 @@
+---
+################################################################################
+# Version of the seminar format. The only valid value for this is '1'. 
+# We may increment this in the future to simplify maintenance of old seminars.
+################################################################################
+version: {{ version }}
+
+################################################################################
+# Sequence number of the seminar file. This is used to keep the iCal up to date.
+# Increment the sequence number each time the seminar file is updated.
+################################################################################
+sequence: {{ sequence }}
+
+################################################################################
+# Date and time of the seminar. In quotes because : is a reserved character.
+# Date must equal the name of this file.
+################################################################################
+date:     {{ date }}
+time:     "{{ time }}"
+time_end: "{{ time_end }}"
+
+################################################################################
+# A seminar file might exist but lack values for some fields. These are 'TBD'. 
+# The only valid value is 'True'. A TBD field should not be present if 'False'.
+################################################################################
+{% if tbd_speakers %}
+tbd_speakers:   {{ tbd_speakers }}
+{% endif %}
+{% if tbd_title %}
+tbd_title:      {{ tbd_title }}
+{% endif %}
+{% if tbd_location %}
+tbd_location:   {{ tbd_location }}
+{% endif %}
+{% if tbd_abstract %}
+tbd_abstract:   {{ tbd_abstract }}
+{% endif %}
+{% if tbd_bio %}
+tbd_bio:        {{ tbd_bio }}
+{% endif %}
+{% if tbd_video %}
+tbd_video:      {{ tbd_video }}
+{% endif %}
+
+################################################################################
+# If a date is "No DUB Seminar", we display it differently.
+#
+# no_seminar: true
+#
+# Seminar files are archived by default. Add this if a seminar should not be.
+#
+# no_archive: true
+################################################################################
+
+################################################################################
+# One or more speakers. Each speaker has name and affiliation.
+#
+# If a speaker does not have an affiliation, the affiliation field can be removed.
+# In this case, the speaker needs a field 'affiliation_none: true'.
+#
+# speakers:
+#   - name: 
+#     - Surname
+#     - First
+#     - Middle
+#     - More
+#     affiliation: Computer Science & Engineering 
+#   - name: 
+#     - Surname
+#     - First
+#     - Middle
+#     - More
+#     affiliation: Information School 
+#   - name: 
+#     - Surname
+#     - First
+#     - Middle
+#     - More
+#     affiliation: Carnegie Mellon University 
+################################################################################
+{% if speakers %}
+speakers:
+  {% for speaker in speakers %}
+  - name:
+    {% for name_part in speaker.name %}
+    - {{ name_part }}
+    {% endfor %}
+    affiliation: {{ speaker.affiliation }}
+  {% endfor %}
+{% endif %}
+
+################################################################################
+# Our core fields are title, location, abstract, bio.
+# title:      "Title in Quotes: Because Colons Cause Errors"
+# 
+# location:   "HUB 334"
+# (optional) location_override_calendar:
+# (optional) location_override_seminar_page:
+#
+# abstract:   |
+#   An abstract can span multiple lines, and can do things across those lines,
+#   like going on for a while or being repetitive.
+#
+#   But the indentation between line wraps is important.
+#
+# bio:        |
+#   And do not even get us started on how a bio can be.
+#
+#   Bio definitely can also span multiple lines like this.
+################################################################################
+title:     "{{ title }}"
+
+location:  "{{ location }}"
+
+abstract:   |
+  {{ abstract }}
+  
+bio:        |
+  {{ bio }}
+
+################################################################################
+# A seminar may have a video. If so, provide the Vimeo video number.
+#
+# video: 142303577
+#
+# If not, this field should not be present 
+################################################################################
+{% if video %}
+video: {{ video }}
+{% endif %}
+---

--- a/base/invoke/tasks/calendar.py
+++ b/base/invoke/tasks/calendar.py
@@ -24,7 +24,8 @@ def compile_calendar():
         for seminar_file_entry
         in os.scandir('_seminars')
         if seminar_file_entry.is_file() and
-           os.path.normpath(seminar_file_entry.path) != os.path.normpath('_seminars/_template.md')
+           os.path.normpath(seminar_file_entry.path) != os.path.normpath('_seminars/_template.md') and
+           os.path.normpath(seminar_file_entry.path) != os.path.normpath('_seminars/_template.j2')
     ]
 
     # Maintain the sequence field for each seminar

--- a/base/invoke/tasks/migrate-seminar-files.py
+++ b/base/invoke/tasks/migrate-seminar-files.py
@@ -1,0 +1,47 @@
+#
+# migrate-seminar-files.py
+#
+# Read all existing seminar files, gather their data, and run them
+# through a Jinja2 template for re-rendering.
+#
+
+import os
+from io import StringIO
+import yaml
+import invoke
+from jinja2 import Environment, FileSystemLoader
+
+SOURCE_DIR = './_seminars/'
+OUTPUT_DIR = './_seminars-new/'
+
+@invoke.task()
+def migrate_seminar_files():
+    env = Environment(
+        loader=FileSystemLoader(searchpath='./_seminars'),
+        trim_blocks=True,
+        lstrip_blocks=True
+    )
+    template = env.get_template('_template.j2')
+
+    for filename in os.listdir(SOURCE_DIR):
+        if not filename.endswith('.md'):
+            continue
+
+        with open(os.path.join(SOURCE_DIR, filename), 'r') as infile:
+            # Strip the first and last lines of the seminar files, which
+            # contain the Jekyll frontmatter delimiters (i.e. '---').
+            seminar_data = yaml.load(StringIO(''.join(infile.readlines()[1:-1])))
+
+            # Make sure the bio and abstract text are free of newlines after
+            # yaml parsing.
+            try:
+                seminar_data['bio'] = seminar_data['bio'].replace('\n', ' ')
+                seminar_data['abstract'] = seminar_data['abstract'].replace('\n', ' ')
+            except KeyError:
+                pass
+
+            with open(os.path.join(OUTPUT_DIR, filename), 'w') as outfile:
+                outfile.write(template.render(seminar_data))
+                outfile.close()
+
+            infile.close()

--- a/tasks.py
+++ b/tasks.py
@@ -7,6 +7,7 @@ task_module_names = [
     'base.invoke.tasks.docker',
     'base.invoke.tasks.jekyll',
     'base.invoke.tasks.update',
+    'base.invoke.tasks.migrate-seminar-files'
 ]
 
 # Create our task collection


### PR DESCRIPTION
Add an `invoke` task that reads all existing seminar files in `./_seminars`, runs them through a Jinja2 template, and renders them into a directory called `./_seminars-new`.

Usage:
```
invoke migrate_seminar_files
```

The templates produced mirror the originals, but we can modify the Jinja2 template to add more information, normalize comments, etc.

Note that this PR does not rewire Jekyll to use the new templates in `./_seminars-new`, but I tested the site with the new templates and from I can tell they render correctly in the browser.

**Questions, etc.**
* Eventually I imagine we'll want to rename `./seminars-new` to `./seminars`, overwriting the current directory?