### PR TITLE
Create 2019-01-25-dubdc.md

### DIFF
--- a/_posts/2019-01-25-dubdc.md
+++ b/_posts/2019-01-25-dubdc.md
@@ -1,0 +1,64 @@
+---
+permalink: /posts/:year/:year:month-:title.html
+layout: base/bar/bar-sidebar-none
+title: "DUB Doctoral Colloquium 2019"
+---
+
+<div class="row" style="margin-bottom: 15px">
+  <div class="col-md-8" markdown="block">
+The DUB doctoral colloquium is a unique opportunity for PhD students to present their key ideas to a diverse HCI audience, and to receive high-quality feedback from their peers and participating DUB faculty. Lively discussions, insights and novel ideas, and new opportunities for cooperation between research groups may emerge from your participation.
+
+PhD students and candidates are invited to present and discuss their work-in-progress or preliminary results in HCI fields at the doctoral colloquium. PhD students and candidates at mid-to late-stages (i.e., third year and above) of their PhD work are invited to submit.
+
+<h4> Submission </h4>
+
+We suggest that all submissions include the following aspects:
+
+1. Problem domain and the specific problem(s) addressed,
+2. Original key idea and corresponding research questions and/or hypotheses,
+3. Brief overview of related work,
+4. Contribution made or expected in the field of HCI,
+5. Research carried out so far and planned ahead, including description of methods and evaluation, and
+6. 2-3 questions that you would specifically like addressed during the colloquium.
+
+Student submissions must be at most 6 pages long, excluding references. Submissions are required to follow the <a href="//chi2019.acm.org/authors/chi-proceedings-format/">CHI Extended Abstract Format</a>. We suggest using the six aspects listed above as section headings. If you wish to diverge from this outline, make sure that the six aspects come out clearly in your submission. 
+
+We will aim to choose participants representing the diversity of participation in DUB, and we are committed to creating a diverse and inclusive colloquium that provides equal access and opportunity for applicants of all racial, ethnic, religious, sexual, gender, cultural, and disability identities.
+
+The final aspect listed, 2-3 specific questions, will help guide the feedback your assigned panelist provides to ensure that you get the most out of the colloquium. The feedback you get will not likely be limited to those questions. Example questions include “How do I cater my research to an academic/industry audience?” or “How should I narrow my research statement so that my contribution is more clear?”. The more specific these questions are, the more productive the feedback is likely to be.
+
+A subset of submissions from past participants can be found at this <a href="https://drive.google.com/open?id=1IwP72acv2CImbC7GoVq_x9ZlqWDYynOv">link</a>.
+
+Please email submissions to <a href="mailto:dub-dc@uw.edu">dub-dc@uw.edu</a>. Submissions are due April 26th, 2019 at 5pm. Notification of acceptance is expected by May 3rd, 2019.
+
+<h4> DUB Doctoral Colloquium Event </h4>
+
+The DUB doctoral colloquium will be held on Friday, May 31st, 2019 (exact time and location TBD). Barring major conflicts (e.g., mandatory class or appointments), students are expected to attend for the entire event. Lunch will be provided. There will be a post-colloquium happy hour after the event.
+
+Participants will each be given a 20-minute time slot for both their presentation and feedback from the panel. Participants may choose how to split their time, but past presentations have normally been 12-15 minutes; participants are encouraged to keep their presentations short so that enough time is left for insightful feedback. The format might be slightly adjusted based on the quantity and diversity of submissions.
+
+The confirmed panelists are:
+- <a href="https://www.microsoft.com/en-us/research/people/ssaponas/">Scott Saponas</a> (Microsoft Research)
+- <a href="http://www.circonflexe.dk/pernillebjorn/">Pernille Bjørn</a> (Human Centered Design & Engineering, Visiting Professor University of Copenhagen)
+- <a href="http://www.audreydesjardins.com/">Audrey Desjardins</a> (School of Art + Art History + Design)
+- <a href="https://homes.cs.washington.edu/~jheer/"> Jeffrey Heer</a> (UW Computer Science & Engineering)
+- <a href="http://bigyipper.com/">Jason Yip</a> (UW Information School)
+
+The HUB is accessible by wheelchair. CART and ASL interpretation is available for this event. To request disability accommodation, contact the Disability Services Office at 206-543-6450 (voice), 206-543-6452 (TTY), 206-685-7264 (fax), or dso@uw.edu.
+
+Please email <a href="mailto:dub-dc@uw.edu">dub-dc@uw.edu</a> with any questions you have about the event or submitting to it.
+
+We're looking forward to your submissions!
+
+\- Benjamin Xie, Susanne Kirchner-Adelhardt, Ravi Karkar, Annie Ross
+  </div>
+  <div class="col-md-4" markdown="block">
+<h4> Important dates </h4>
+
+Submission deadline: April 26th, 2019 at 5pm
+
+Notification: May 3rd, 2019
+
+Event: May 31st, 2019
+  </div>
+</div>


### PR DESCRIPTION
Creating post for 2019 DUB DC. Adaptation from 2018 DUB DC post. Dates, panelists, organizers all updated. Location and exact time TBD. Example submissions from 2017 until we get permission for 2018 participants.