### PR TITLE
update DC 2019 page to show submissions from 2018

### DIFF
--- a/_posts/2019-01-25-dubdc.md
+++ b/_posts/2019-01-25-dubdc.md
@@ -27,7 +27,7 @@ We will aim to choose participants representing the diversity of participation i
 
 The final aspect listed, 2-3 specific questions, will help guide the feedback your assigned panelist provides to ensure that you get the most out of the colloquium. The feedback you get will not likely be limited to those questions. Example questions include “How do I cater my research to an academic/industry audience?” or “How should I narrow my research statement so that my contribution is more clear?”. The more specific these questions are, the more productive the feedback is likely to be.
 
-A subset of submissions from past participants can be found at this <a href="https://drive.google.com/open?id=1IwP72acv2CImbC7GoVq_x9ZlqWDYynOv">link</a>.
+A subset of submissions from past participants can be found at this <a href="https://drive.google.com/open?id=1Fx6EtHGC49AVKv815xw762Pcom6adnpb">link</a> (UW NetID required).
 
 Please email submissions to <a href="mailto:dub-dc@uw.edu">dub-dc@uw.edu</a>. Submissions are due April 26th, 2019 at 5pm. Notification of acceptance is expected by May 3rd, 2019.
 


### PR DESCRIPTION
changing submissions link (Drive folder) from 2017 submissions to 2018 submissions (access set to UW view only)