### PR TITLE
updated DC 2019 page w/ submissions from 2018

### DIFF
--- a/_posts/2019-01-25-dubdc.md
+++ b/_posts/2019-01-25-dubdc.md
@@ -27,13 +27,16 @@ We will aim to choose participants representing the diversity of participation i
 
 The final aspect listed, 2-3 specific questions, will help guide the feedback your assigned panelist provides to ensure that you get the most out of the colloquium. The feedback you get will not likely be limited to those questions. Example questions include “How do I cater my research to an academic/industry audience?” or “How should I narrow my research statement so that my contribution is more clear?”. The more specific these questions are, the more productive the feedback is likely to be.
 
-A subset of submissions from past participants can be found at this <a href="https://drive.google.com/open?id=1IwP72acv2CImbC7GoVq_x9ZlqWDYynOv">link</a>.
+A subset of submissions from past participants are linked here to serve as examples (UW NetID required): <a href="https://drive.google.com/a/uw.edu/file/d/135S92PXg5yU09RJpdDpIqeyHXYnThWvd/view?usp=sharing">example 1</a>, <a href="https://drive.google.com/a/uw.edu/file/d/1V1B7ZlgJfrjvRafdeoM_GgZr00ULs0oE/view?usp=sharing
+">example 2</a>, <a href="https://drive.google.com/a/uw.edu/file/d/1VpgVpjDnvQxGpmifZnjMJakl_FlYYgpu/view?usp=sharing
+">example 3</a>, <a href="https://drive.google.com/a/uw.edu/file/d/1txUqahhx5QzmhR5cUt1CJCfHIM8KnpU_/view?usp=sharing
+">example 4</a>.
 
 Please email submissions to <a href="mailto:dub-dc@uw.edu">dub-dc@uw.edu</a>. Submissions are due April 26th, 2019 at 5pm. Notification of acceptance is expected by May 3rd, 2019.
 
 <h4> DUB Doctoral Colloquium Event </h4>
 
-The DUB doctoral colloquium will be held on Friday, May 31st, 2019 (exact time and location TBD). Barring major conflicts (e.g., mandatory class or appointments), students are expected to attend for the entire event. Lunch will be provided. There will be a post-colloquium happy hour after the event.
+The DUB doctoral colloquium will be held Friday, May 31st, 2019 on UW Seattle campus (exact time and location TBD). Barring major conflicts (e.g., mandatory class or appointments), students are expected to attend for the entire event. Lunch will be provided. There will be a post-colloquium happy hour after the event.
 
 Participants will each be given a 20-minute time slot for both their presentation and feedback from the panel. Participants may choose how to split their time, but past presentations have normally been 12-15 minutes; participants are encouraged to keep their presentations short so that enough time is left for insightful feedback. The format might be slightly adjusted based on the quantity and diversity of submissions.
 


### PR DESCRIPTION
- removed 2017 submissions
- had to add links to each submission individually b/c team drive doesn't allow sharing of folders
- UW NetID required to view examples