### PR TITLE
2019-08-21: added abstract & bio for MHCI+D event

### DIFF
--- a/_seminars/2019-08-21.md
+++ b/_seminars/2019-08-21.md
@@ -150,7 +150,7 @@ abstract: |
 bio: |
   The Master of Human-Computer Interaction and Design (MHCI+D) is offered by four departments: Computer Science & Engineering, Human Centered Design & Engineering, the Information School and Division of Design in the School of Art + Art History + Design, along with faculty from other UW departments. These four units comprise the award-winning research group known as DUB (Design: Use: Build).
 
-This unique, cross-disciplinary approach seeks to educate a new generation of designers, engineers and researchers who can successfully combine the creative aspects of design and the study of human behavior with the analytical techniques of engineering. Graduates of the Master of Human-Computer Interaction and Design program will use their knowledge to create innovative products and technologies.
+  This unique, cross-disciplinary approach seeks to educate a new generation of designers, engineers and researchers who can successfully combine the creative aspects of design and the study of human behavior with the analytical techniques of engineering. Graduates of the Master of Human-Computer Interaction and Design program will use their knowledge to create innovative products and technologies.
 
 More info on MHCI+D: [https://mhcid.washington.edu/](https://mhcid.washington.edu/)
 

--- a/_seminars/2019-08-21.md
+++ b/_seminars/2019-08-21.md
@@ -13,7 +13,7 @@ version: 1
 # - This is used to keep the iCal up to date.
 # - Increment the sequence each time the seminar file is updated.
 ################################################################################
-sequence: 3
+sequence: 4
 
 ################################################################################
 # Date and time of the seminar.
@@ -32,9 +32,6 @@ time_end: "1:30 PM"
 # - A field should not be present if 'false'.
 ################################################################################
 tbd_speakers:   True
-tbd_location:   True
-tbd_abstract:   True
-tbd_bio:        True
 tbd_video:      True
 
 ################################################################################
@@ -145,13 +142,17 @@ speakers:
 ################################################################################
 title:      "MHCI+D Capstone Presentations"
 
-location:   "TBD"
+location:   "HUB Lyceum"
 
 abstract: |
-  TBD
+  In this final DUB Seminar for the 2018–2019 academic year, the MHCI+D capstone teams will present 1-2 minute lightning talks, followed by a showcase of their final prototypes in a poster session.
 
 bio: |
-  TBD
+  The Master of Human-Computer Interaction and Design (MHCI+D) is offered by four departments: Computer Science & Engineering, Human Centered Design & Engineering, the Information School and Division of Design in the School of Art + Art History + Design, along with faculty from other UW departments. These four units comprise the award-winning research group known as DUB (Design: Use: Build).
+
+This unique, cross-disciplinary approach seeks to educate a new generation of designers, engineers and researchers who can successfully combine the creative aspects of design and the study of human behavior with the analytical techniques of engineering. Graduates of the Master of Human-Computer Interaction and Design program will use their knowledge to create innovative products and technologies.
+
+More info on MHCI+D: [https://mhcid.washington.edu/](https://mhcid.washington.edu/)
 
 ################################################################################
 # A seminar may have a video.

--- a/_seminars/2019-08-21.md
+++ b/_seminars/2019-08-21.md
@@ -142,7 +142,7 @@ speakers:
 ################################################################################
 title:      "MHCI+D Capstone Presentations"
 
-location:   "HUB Lyceum"
+location:   "HUB 160: Lyceum"
 
 abstract: |
   In this final DUB Seminar for the 2018–2019 academic year, the MHCI+D capstone teams will present 1-2 minute lightning talks, followed by a showcase of their final prototypes in a poster session.

--- a/_seminars/2019-08-21.md
+++ b/_seminars/2019-08-21.md
@@ -152,7 +152,7 @@ bio: |
 
   This unique, cross-disciplinary approach seeks to educate a new generation of designers, engineers and researchers who can successfully combine the creative aspects of design and the study of human behavior with the analytical techniques of engineering. Graduates of the Master of Human-Computer Interaction and Design program will use their knowledge to create innovative products and technologies.
 
-More info on MHCI+D: [https://mhcid.washington.edu/](https://mhcid.washington.edu/)
+  More info on MHCI+D: [https://mhcid.washington.edu/](https://mhcid.washington.edu/)
 
 ################################################################################
 # A seminar may have a video.

--- a/tests/fast/test_seminars.py
+++ b/tests/fast/test_seminars.py
@@ -235,6 +235,7 @@ class TestSeminars(unittest.TestCase):
                         'GIX',
                         'Haggett Hall Cascade Room',
                         'HUB 145',
+                        'HUB 160: Lyceum',
                         'HUB 214',
                         'HUB 250',
                         'HUB 332',


### PR DESCRIPTION
Abstract & location provided by Emily. Bio taken from MHCI+D website. No speakers listed.