### PR TITLE
add 2023 DUB REU program

### DIFF
--- a/_posts/2023-01-06-dubreu.md
+++ b/_posts/2023-01-06-dubreu.md
@@ -34,7 +34,7 @@ Human-Computer Interaction and Design faculty across DUB, including in:
 **Contact Information**
 </div>
 <div class="col-md-8" markdown="block">
-Amy Zhang <axz [at] cs.uw.edu>, Leilani Battle <leibatt [at] cs.washington.edu>
+Amy Zhang <axz [at] cs.uw.edu>,<br>Leilani Battle <leibatt [at] cs.washington.edu>
 </div>
 </div>
 

--- a/_posts/2023-01-06-dubreu.md
+++ b/_posts/2023-01-06-dubreu.md
@@ -1,0 +1,98 @@
+---
+permalink: /posts/:year/dubreu.html
+layout: base/bar/bar-sidebar-right
+title: "DUB REU Program Summer 2023"
+---
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Research Position Title**
+</div>
+<div class="col-md-8" markdown="block">
+DUB REU Research Assistant
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Research Faculty**
+</div>
+<div class="col-md-8" markdown="block">
+Human-Computer Interaction and Design faculty across DUB, including in:
+
+- [Computer Science & Engineering](http://www.cs.washington.edu)
+- [The Division of Design](http://art.washington.edu/design)
+- [Human Centered Design & Engineering](http://www.hcde.washington.edu)
+- [The Information School](http://ischool.uw.edu)
+
+<!-- Richard Anderson, Anat Caspi, Maya Cakmak, Leah Findlater, James Fogarty, Jon Froehlich, Julie Kientz, Andy Ko, Jennifer Mankoff, Kate Starbird -->
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Contact Information**
+</div>
+<div class="col-md-8" markdown="block">
+Amy Zhang <axz [at] cs.uw.edu>, Leilani Battle <leibatt [at] cs.washington.edu>
+</div>
+</div>
+
+DUB is a grassroots alliance of faculty, students, researchers, and industry partners interested in Human Computer Interaction & Design at the University of Washington. Our mission is to bring together an interdisciplinary group of people to share ideas, collaborate on research, and advance teaching related to the interaction between design, people, and technology.
+
+This year we are offering a summer research opportunity, available to undergraduate students. This research program encourages applications from students who would like to conduct research in the field of HCI, on topics ranging from accessibility, to fabrication, to health, to ICT4D, to robotics. We seek broad participation, including members of underrepresented groups as defined by the National Science Foundation (i.e., African American, Hispanic, Native American, people with disabilities) who may be considering further graduate study in human-computer interaction or computer science.
+
+If you are accepted into the REU program, you will be invited to participate in a paid 9-week internship during the summer in a research laboratory at the University of Washington. Based on your application, you will be matched with a specific project and mentored by the faculty member and associated graduate students or postdocs. You will learn about research through engagement in the project to which you are matched, through interactions with other students, and through weekly mentoring seminars focused on research and associated skills. Topics covered may include admissions, career opportunities, research ethics, and research paper writing. In addition, you will be invited to attend the DUB seminar for exposure to a wide range of research in HCI.
+
+This experience will be excellent preparation if you are considering pursuing a Masters or Ph.D. degree. Past undergraduate students in DUB have been offered the chance to author a publication, and undergraduate interns who perform well frequently request reference letters from their mentors.   As such, this program is well suited to a student in the summer between their junior year and senior year of college. Students in other years may also apply, but students who will have already graduated by Summer 2023 are not eligible.
+
+### REU Program Dates
+The formal program begins on June 20 with a welcome reception and orientation, then concludes on August 18 with an afternoon poster session. Students are expected to be present and engaged for the entire 9-week period, work 40 hours a week, and make time to attend scheduled events such as the welcome reception, seminar, and final poster session.
+
+Some students may additionally make arrangements with individual faculty to arrive earlier and/or stay later.
+
+### REU Program Benefits
+This REU program is not a funded NSF REU site. Instead, each accepted REU intern is hired and funded by the matched faculty mentor. As such, there may be variation across students in the program in terms of their funding, duration, start and end dates, and benefits. The details of this information should be discussed with one's matched faculty mentor.
+In general though, many of the REU positions are funded through an NSF source, and the NSF provides guidance that a stipend should be $600 per student per week, with a maximum stipend of $8,000 over the entire summer.
+Based on this guidance, stipend support can vary (e.g., a 9-week summer REU internship might be associated with a $5400 stipend, longer internships with additional stipend).
+Funding support may also be available for participants with disabilities through Access Computing; interested applicants should include a note in their application form.
+
+Housing will not be provided, but is available through the university:
+
+<https://hfs.uw.edu/Guest-Housing>
+
+## Information about Applying
+
+Students must be a U.S. Citizen or permanent resident to apply. Ths NSF is the primary funding source for the program and requires this for its funding of REU positions.
+
+Students must be 18 years old or older.
+
+Submission of an application indicates that the applicant agrees to be present for the entire summer program period.
+
+The expected commitment is 40 hours per week, with no additional classes or jobs.
+
+In addition, a strong application will have a minimum GPA of 3.5 and good class standing and/or grades in subjects relevant to the research area of interest.
+
+We expect the program to have 10 to 20 positions this summer, though the number of students will depend on funding and the number and strength of the applications.
+
+## Application Instructions for Summer 2023
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Application Deadline**
+</div>
+<div class="col-md-8" markdown="block">
+Deadline for applications is Jan 27, 2023
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Application Link**
+</div>
+<div class="col-md-8" markdown="block">
+<https://forms.gle/ZEMDCor4pPAU4wXH9>
+</div>
+</div>
+
+In addition to completing the above form, please have one recommender submit a letter of recommendation to Leilani Battle <leibatt [at] cs.washington.edu> to complete your application.

--- a/gettinginvolved.md
+++ b/gettinginvolved.md
@@ -636,9 +636,9 @@ You can also apply to multiple programs. The important thing is to come join us!
 ### Summer Research Experiences for Undergraduates
 
 DUB faculty coordinate a set of summer REU activities for undergraduates from within and outside the University of Washington.
-Information about the Summer 2022 program can found here:
+Information about the Summer 2023 program can found here:
 
-[DUB REU Program Summer 2022]({{ site.baseref }}/posts/2022/dubreu.html)
+[DUB REU Program Summer 2023]({{ site.baseref }}/posts/2023/dubreu.html)
 
 </div>
 </div>


### PR DESCRIPTION
Note the additional language I added under REU Program benefits in response to some feedback from REU students this summer:

"This REU program is not a funded NSF REU site. Instead, each accepted REU intern is hired and funded by the matched faculty mentor. As such, there may be variation across students in the program in terms of their funding, duration, start and end dates, and benefits. The details of this information should be discussed with one's matched faculty mentor.
In general though,..."

Welcome to any feedback on this language. CC @leibatt 