### PR TITLE
Include links to LaTeX and word templates

### DIFF
--- a/_posts/2023-04-03-dubdc.md
+++ b/_posts/2023-04-03-dubdc.md
@@ -21,7 +21,7 @@ We suggest that all submissions include the following aspects:
 5. Research carried out so far and planned ahead, including description of methods and evaluation, and
 6. 2-3 questions that you would specifically like addressed during the colloquium.
 
-Student submissions must be at most 6 pages long, excluding references. Submissions are required to follow the <a href="//chi2019.acm.org/authors/chi-proceedings-format/">CHI Extended Abstract Format (2019)</a>. We suggest using the six aspects listed above as section headings. If you wish to diverge from this outline, make sure that the six aspects come out clearly in your submission. 
+Student submissions must be at most 6 pages long, excluding references. Submissions are required to follow the <a href="//chi2019.acm.org/authors/chi-proceedings-format/">CHI Extended Abstract Format (2019)</a> (<a href="https://www.overleaf.com/latex/templates/association-for-computing-machinery-acm-sigchi-extended-abstract-template/zzzfqvkmrfzn">LaTeX template</a> and <a href="http://chi2019.acm.org/wp-content/uploads/2018/12/CHI19-EA-sample-file-1.docx">Microsoft Word template</a> available). We suggest using the six aspects listed above as section headings. If you wish to diverge from this outline, make sure that the six aspects come out clearly in your submission. 
 
 We will aim to choose participants representing the diversity of participation in DUB, and we are committed to creating a diverse and inclusive colloquium that provides equal access and opportunity for applicants of all racial, ethnic, religious, sexual, gender, cultural, and disability identities.
 


### PR DESCRIPTION
The CHI 2019 original website seems to have some issue and the links aren't quite clickable unless you look into the source code.