### PR TITLE
DUB REU mini-site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ navbar:
       link: 'aboutdub.html'
     - text: 'DUB Seminar'
       link: 'seminar.html'
+    - text: 'DUB REU'
+      link: 'reu/index.html'
 #    - text: 'People'
 #      link: 'people.html'
 #    - text: 'Resources'

--- a/_posts/2019-01-20-dubreu.md
+++ b/_posts/2019-01-20-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/:year:month-:title.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2019"
+published: false
 ---
 
 <div class="row">

--- a/_posts/2020-01-03-dubreu.md
+++ b/_posts/2020-01-03-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/:year:month-:title.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2020"
+published: false
 ---
 
 <div class="row">

--- a/_posts/2021-01-01-dubreu.md
+++ b/_posts/2021-01-01-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/dubreu.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2021"
+published: false
 ---
 
 <div class="row">

--- a/_posts/2022-01-06-dubreu.md
+++ b/_posts/2022-01-06-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/dubreu.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2022"
+published: false
 ---
 
 <div class="row">

--- a/_posts/2023-01-06-dubreu.md
+++ b/_posts/2023-01-06-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/dubreu.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2023"
+published: false
 ---
 
 <div class="row">

--- a/_posts/2024-01-02-dubreu.md
+++ b/_posts/2024-01-02-dubreu.md
@@ -2,6 +2,7 @@
 permalink: /posts/:year/dubreu.html
 layout: base/bar/bar-sidebar-right
 title: "DUB REU Program Summer 2024"
+published: false
 ---
 
 <div class="row">

--- a/reu/faq-2025.md
+++ b/reu/faq-2025.md
@@ -26,26 +26,26 @@ As of October 2024, the following faculty members have indicated that they are w
 
 Note that this is not an exhaustive list as there may be faculty members who sign up later in the process. If you are interested in working with a specific faculty member, we encourage you to indicate that in your application, regardless of whether that faculty member is listed on this page or not.
 
-## When do I get paid?
-
-TBD
-
-## What is the stipend?
-
-TBD.
-
 ## Can I participate in this program remotely?
 
 No. All students in this program will need to be in the Seattle area and come to the UW Seattle campus regularly.
-
-## How can I find housing?
-
-We do not arrange for housing for students participating in the program. However, housing is [available through the University](https://hfs.uw.edu/Guest-Housing). In the past, participants have also made their own arrangements to rent places to stay near campus.
 
 ## Do I need a car to commute to campus?
 
 No. The UW Seattle campus is well connected by public transit, including buses and light rail. The UW Transportation Services website lists a number of [options](https://transportation.uw.edu/getting-here) for commuting to the campus.
 
+## When do I get paid?
+
+This may vary. See the [student expectations document](https://docs.google.com/document/d/1rZp9QP83v2BVWevAMsBJi4Aj-jCYtmRv10kwtyINmf4/edit?usp=sharing) for details.
+
+## What is the stipend?
+
+This may vary. See the [student expectations document](https://docs.google.com/document/d/1rZp9QP83v2BVWevAMsBJi4Aj-jCYtmRv10kwtyINmf4/edit?usp=sharing) for details.
+
 ## Apart from being able to participate in conducting research, what else can I expect from this program?
 
 We offer a range of opportunities for students to develop their research skills and knowledge. These include opportunities to attend the [DUB seminar series](https://dub.washington.edu/seminar.html), lunches with faculty members from across the campus, sessions with current graduate students, and a poster session to present and share your work with members of the DUB community. Furthermore, we value developing a community of undergraduate researchers, and encourage members of a REU cohort to self-organize social activities.
+
+## I have a question that is not answered here. Whom do I contact?
+
+You can email <dubreu [at] uw.edu> with any questions that you may have about the program.

--- a/reu/faq-2025.md
+++ b/reu/faq-2025.md
@@ -1,0 +1,51 @@
+---
+layout: base/bar/bar-sidebar-right
+title: "DUB REU Program Summer 2025 - Frequently Asked Questions"
+---
+
+<a onclick="window.history.back()" href="#">⟵ Back</a>
+
+## Which faculty members are recruiting REU students this year?
+
+As of October 2024, the following faculty members have indicated that they are willing to host a REU student in summer 2025:
+
+* Katya Cherukumilli, HCDE, [https://depts.washington.edu/swellhcde/](https://depts.washington.edu/swellhcde/)  
+* Kurtis Heimerl, CSE, [https://kurti.sh/](https://kurti.sh/)  
+* Julie Kientz, HCDE, [https://faculty.washington.edu/jkientz/](https://faculty.washington.edu/jkientz/)  
+* R. Benjamin Shapiro, CSE, [https://benshapi.ro/](https://benshapi.ro/)  
+* James Pierce, Design, [https://jamesjpierce.com/](https://jamesjpierce.com/)  
+* Maya Cakmak, CSE, [https://www.mayacakmak.io/](https://www.mayacakmak.io/)  
+* Tanu Mitra, iSchool, [https://faculty.washington.edu/tmitra/](https://faculty.washington.edu/tmitra/)  
+* Amy Ko, iSchool, [https://faculty.washington.edu/ajko/](https://faculty.washington.edu/ajko/)  
+* Leilani Battle, CSE, [https://homes.cs.washington.edu/\~leibatt/](https://homes.cs.washington.edu/~leibatt/bio.html)  
+* Sayamindu Dasgupta, HCDE, [https://unmad.in/](https://unmad.in/)  
+* Amy Zhang, CSE, [https://homes.cs.washington.edu/\~axz](https://homes.cs.washington.edu/~axz)  
+* Gary Hsieh, HCDE, [https://faculty.washington.edu/garyhs/](https://faculty.washington.edu/garyhs/)   
+* Jennifer Mankoff, CSE, [https://make4all.org/](https://make4all.org/)   
+* Benjamin Mako Hill, Communication, [https://mako.cc/](https://mako.cc/) 
+
+Note that this is not an exhaustive list as there may be faculty members who sign up later in the process. If you are interested in working with a specific faculty member, we encourage you to indicate that in your application, regardless of whether that faculty member is listed on this page or not.
+
+## When do I get paid?
+
+TBD
+
+## What is the stipend?
+
+TBD.
+
+## Can I participate in this program remotely?
+
+No. All students in this program will need to be in the Seattle area and come to the UW Seattle campus regularly.
+
+## How can I find housing?
+
+We do not arrange for housing for students participating in the program. However, housing is [available through the University](https://hfs.uw.edu/Guest-Housing). In the past, participants have also made their own arrangements to rent places to stay near campus.
+
+## Do I need a car to commute to campus?
+
+No. The UW Seattle campus is well connected by public transit, including buses and light rail. The UW Transportation Services website lists a number of [options](https://transportation.uw.edu/getting-here) for commuting to the campus.
+
+## Apart from being able to participate in conducting research, what else can I expect from this program?
+
+We offer a range of opportunities for students to develop their research skills and knowledge. These include opportunities to attend the [DUB seminar series](https://dub.washington.edu/seminar.html), lunches with faculty members from across the campus, sessions with current graduate students, and a poster session to present and share your work with members of the DUB community. Furthermore, we value developing a community of undergraduate researchers, and encourage members of a REU cohort to self-organize social activities.

--- a/reu/faq.md
+++ b/reu/faq.md
@@ -1,11 +1,11 @@
 ---
 layout: base/bar/bar-sidebar-right
-title: "DUB REU Program Summer 2025 - Frequently Asked Questions"
+title: "DUB REU Program - Frequently Asked Questions"
 ---
 
 <a onclick="window.history.back()" href="#">⟵ Back</a>
 
-## Which faculty members are recruiting REU students this year?
+## Which faculty members are recruiting REU students for summer 2025?
 
 As of October 2024, the following faculty members have indicated that they are willing to host a REU student in summer 2025:
 

--- a/reu/index.md
+++ b/reu/index.md
@@ -86,7 +86,7 @@ In addition, a strong application will have a minimum GPA of 3.5 and good class 
 
 We expect the program to have 10 to 20 positions this summer, though the number of students will depend on funding and the number and strength of the applications.
 
-We require one letter of recommendation for an application.
+We require one letter of recommendation for an application, to be submitted by the application deadline.
 
 For additional information, please review the [FAQ](faq.html).
 

--- a/reu/index.md
+++ b/reu/index.md
@@ -90,7 +90,7 @@ We expect the program to have 10 to 20 positions this summer, though the number 
 
 We require one letter of recommendation for an application.
 
-For additional information, please review the [FAQ](faq-2025.html) for this year.
+For additional information, please review the [FAQ](faq.html).
 
 ## Application Instructions for Summer 2025
 

--- a/reu/index.md
+++ b/reu/index.md
@@ -48,7 +48,7 @@ Human-Computer Interaction and Design faculty across DUB, including in:
 **Contact Information**
 </div>
 <div class="col-md-8" markdown="block">
-Amy Zhang <axz [at] cs.uw.edu>,<br>Leilani Battle <leibatt [at] cs.washington.edu>,<br>Sayamindu Dasgupta <sdg1 [at] uw.edu>,<br>Tanu Mitra <tmitra [at] uw.edu> 
+<dubreu [at] uw.edu>
 </div>
 </div>
 
@@ -60,19 +60,19 @@ If you are accepted into the REU program, you will be invited to participate in 
 
 This experience will be excellent preparation if you are considering pursuing a Masters or Ph.D. degree. Past undergraduate students in DUB have been offered the chance to author a publication, and undergraduate interns who perform well frequently request reference letters from their mentors.  As such, this program is well suited to a student in the summer between their junior year and senior year of college. Students in other years may also apply, but students who will have already graduated by Summer 2025 are not eligible.
 
+For more information, refer to the [student expectations document](https://docs.google.com/document/d/1rZp9QP83v2BVWevAMsBJi4Aj-jCYtmRv10kwtyINmf4/edit?usp=sharing) for this program.
+
 ### REU Program Dates
-The formal program begins on June 23 with a welcome reception and orientation, then concludes on August 22 with an afternoon poster session. Students are expected to be present and engaged for the entire 9-week period, work 40 hours a week, and make time to attend scheduled events such as the welcome reception, seminar, and final poster session.
+The formal program begins on June 16 with a welcome reception and orientation, then concludes on August 15 with an afternoon poster session. Students are expected to be present and engaged for the entire 9-week period, work 40 hours a week, and make time to attend scheduled events such as the welcome reception, seminar, and final poster session.
 
 Some students may additionally make arrangements with individual faculty to arrive earlier and/or stay later.
 
 ### REU Program Benefits
-Currently, this REU program is a funded NSF REU site (award ID: [2348926](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2348926)). However, the cohort for this year may also include accepted REU interns hired and funded by faculty mentors who have individual REU supplemental grants or similar funding for their projects. As such, there may be variation across students in the program in terms of their funding, duration, start and end dates, and benefits. The details of this information should be discussed with one's matched faculty mentor. In general though, many of the REU positions are funded through an NSF source, and the NSF provides guidance that a stipend should be $600 per student per week, with a maximum stipend of $8,000 over the entire summer.
+Currently, this REU program is a funded NSF REU site (award ID: [2348926](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2348926)). However, the cohort for this year may also include REU interns hired and funded by faculty mentors who have individual REU supplemental grants or similar funding for their projects. As such, there may be variation across students in the program in terms of their funding, duration, start and end dates, and benefits. The details of this information should be discussed with one's matched faculty mentor. For more information on this, refer to the [student expectations document](https://docs.google.com/document/d/1rZp9QP83v2BVWevAMsBJi4Aj-jCYtmRv10kwtyINmf4/edit?usp=sharing) for this program.
 
-Based on this guidance, stipend support can vary (e.g., a 9-week summer REU internship might be associated with a $5400 stipend, longer internships with additional stipend). Funding support may also be available for participants with disabilities through Access Computing; interested applicants should include a note in their application form.
+<!-- Housing will not be provided, but is available through the university:
 
-Housing will not be provided, but is available through the university:
-
-<https://hfs.uw.edu/Guest-Housing>
+<https://hfs.uw.edu/Guest-Housing> -->
 
 ## Information about Applying
 
@@ -82,11 +82,13 @@ Students must be 18 years old or older.
 
 Submission of an application indicates that the applicant agrees to be present for the entire summer program period.
 
-The expected commitment is 40 hours per week, with no additional classes or jobs.
+The expected commitment is 40 hours per week, with no additional classes, or jobs, or other REUs.
 
 In addition, a strong application will have a minimum GPA of 3.5 and good class standing and/or grades in subjects relevant to the research area of interest.
 
 We expect the program to have 10 to 20 positions this summer, though the number of students will depend on funding and the number and strength of the applications.
+
+We require one letter of recommendation for an application.
 
 For additional information, please review the [FAQ](faq-2025.html) for this year.
 
@@ -106,8 +108,15 @@ Deadline for applications is January 31st, 2025
 **Application Link**
 </div>
 <div class="col-md-8" markdown="block">
-TBD
+<https://etap.nsf.gov/award/7098/opportunity/10161>
 </div>
 </div>
 
-<!-- In addition to completing the above form, please have one recommender submit a letter of recommendation to Leilani Battle <leibatt [at] cs.washington.edu> to complete your application. -->
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Contact Email**
+</div>
+<div class="col-md-8" markdown="block">
+<dubreu [at] uw.edu>
+</div>
+</div>

--- a/reu/index.md
+++ b/reu/index.md
@@ -5,14 +5,12 @@ title: "DUB REU Program Summer 2025"
 
 <div class="sidebar_start"></div>
 
-<h4>Previous REUs</h4>
+<h4>Related Links</h4>
 
 <ul class="nav nav-pills nav-stacked">
-  <li><a href="{{ site.baseurl }}/posts/2024/dubreu.html">2024</a></li>
-  <li><a href="{{ site.baseurl }}/posts/2023/dubreu.html">2023</a></li>
-  <li><a href="{{ site.baseurl }}/posts/2022/dubreu.html">2022</a></li>
-  <li><a href="{{ site.baseurl }}/posts/2021/dubreu.html">2021</a></li>
-  <li><a href="{{ site.baseurl }}/posts/2019/201901-dubreu.html">2020</a></li>
+  <li><a href="faq.html">DUB REU Frequently Asked Questions</a></li>
+  <li><a href="https://docs.google.com/document/d/1rZp9QP83v2BVWevAMsBJi4Aj-jCYtmRv10kwtyINmf4/edit?usp=sharing">DUB REU Student Expectations</a></li>
+  <li><a href="mailto:dubreu@uw.edu">Contact Email</a></li>
 </ul>
 
 <div class="sidebar_end"></div>

--- a/reu/index.md
+++ b/reu/index.md
@@ -1,0 +1,113 @@
+---
+layout: base/bar/bar-sidebar-right
+title: "DUB REU Program Summer 2025"
+---
+
+<div class="sidebar_start"></div>
+
+<h4>Previous REUs</h4>
+
+<ul class="nav nav-pills nav-stacked">
+  <li><a href="{{ site.baseurl }}/posts/2024/dubreu.html">2024</a></li>
+  <li><a href="{{ site.baseurl }}/posts/2023/dubreu.html">2023</a></li>
+  <li><a href="{{ site.baseurl }}/posts/2022/dubreu.html">2022</a></li>
+  <li><a href="{{ site.baseurl }}/posts/2021/dubreu.html">2021</a></li>
+  <li><a href="{{ site.baseurl }}/posts/2019/201901-dubreu.html">2020</a></li>
+</ul>
+
+<div class="sidebar_end"></div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Research Position Title**
+</div>
+<div class="col-md-8" markdown="block">
+DUB REU Research Assistant
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Research Faculty**
+</div>
+<div class="col-md-8" markdown="block">
+Human-Computer Interaction and Design faculty across DUB, including in:
+
+- [Computer Science & Engineering](http://www.cs.washington.edu)
+- [The Division of Design](http://art.washington.edu/design)
+- [Human Centered Design & Engineering](http://www.hcde.washington.edu)
+- [The Information School](http://ischool.uw.edu)
+
+<!-- faculty members  -->
+
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Contact Information**
+</div>
+<div class="col-md-8" markdown="block">
+Amy Zhang <axz [at] cs.uw.edu>,<br>Leilani Battle <leibatt [at] cs.washington.edu>,<br>Sayamindu Dasgupta <sdg1 [at] uw.edu>,<br>Tanu Mitra <tmitra [at] uw.edu> 
+</div>
+</div>
+
+DUB is a grassroots alliance of faculty, students, researchers, and industry partners interested in Human Computer Interaction & Design at the University of Washington. Our mission is to bring together an interdisciplinary group of people to share ideas, collaborate on research, and advance teaching related to the interaction between design, people, and technology.
+
+This year we are offering a summer research opportunity, available to undergraduate students. This research program encourages applications from students who would like to conduct research in the field of HCI, on topics ranging from accessibility, to fabrication, to health, to ICT4D, to robotics. We seek broad participation, including members of underrepresented groups as defined by the National Science Foundation (i.e., African American, Hispanic, Native American, people with disabilities) who may be considering further graduate study in human-computer interaction or computer science.
+
+If you are accepted into the REU program, you will be invited to participate in a paid 9-week internship during the summer in a research laboratory at the University of Washington. Based on your application, you will be matched with a specific project and mentored by the faculty member and associated graduate students or postdocs. You will learn about research through engagement in the project to which you are matched, through interactions with other students, and through weekly mentoring seminars focused on research and associated skills. Topics covered may include graduate admissions, career opportunities, research ethics, and research paper writing. In addition, you will be invited to attend the DUB seminar for exposure to a wide range of research in HCI.
+
+This experience will be excellent preparation if you are considering pursuing a Masters or Ph.D. degree. Past undergraduate students in DUB have been offered the chance to author a publication, and undergraduate interns who perform well frequently request reference letters from their mentors.  As such, this program is well suited to a student in the summer between their junior year and senior year of college. Students in other years may also apply, but students who will have already graduated by Summer 2025 are not eligible.
+
+### REU Program Dates
+The formal program begins on June 23 with a welcome reception and orientation, then concludes on August 22 with an afternoon poster session. Students are expected to be present and engaged for the entire 9-week period, work 40 hours a week, and make time to attend scheduled events such as the welcome reception, seminar, and final poster session.
+
+Some students may additionally make arrangements with individual faculty to arrive earlier and/or stay later.
+
+### REU Program Benefits
+Currently, this REU program is a funded NSF REU site (award ID: [2348926](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2348926)). However, the cohort for this year may also include accepted REU interns hired and funded by faculty mentors who have individual REU supplemental grants or similar funding for their projects. As such, there may be variation across students in the program in terms of their funding, duration, start and end dates, and benefits. The details of this information should be discussed with one's matched faculty mentor. In general though, many of the REU positions are funded through an NSF source, and the NSF provides guidance that a stipend should be $600 per student per week, with a maximum stipend of $8,000 over the entire summer.
+
+Based on this guidance, stipend support can vary (e.g., a 9-week summer REU internship might be associated with a $5400 stipend, longer internships with additional stipend). Funding support may also be available for participants with disabilities through Access Computing; interested applicants should include a note in their application form.
+
+Housing will not be provided, but is available through the university:
+
+<https://hfs.uw.edu/Guest-Housing>
+
+## Information about Applying
+
+Students must be a U.S. Citizen or permanent resident to apply. Ths NSF is the primary funding source for the program and requires this for its funding of REU positions.
+
+Students must be 18 years old or older.
+
+Submission of an application indicates that the applicant agrees to be present for the entire summer program period.
+
+The expected commitment is 40 hours per week, with no additional classes or jobs.
+
+In addition, a strong application will have a minimum GPA of 3.5 and good class standing and/or grades in subjects relevant to the research area of interest.
+
+We expect the program to have 10 to 20 positions this summer, though the number of students will depend on funding and the number and strength of the applications.
+
+For additional information, please review the [FAQ](faq-2025.html) for this year.
+
+## Application Instructions for Summer 2025
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Application Deadline**
+</div>
+<div class="col-md-8" markdown="block">
+Deadline for applications is January 31st, 2025
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-4" markdown="block">
+**Application Link**
+</div>
+<div class="col-md-8" markdown="block">
+TBD
+</div>
+</div>
+
+<!-- In addition to completing the above form, please have one recommender submit a letter of recommendation to Leilani Battle <leibatt [at] cs.washington.edu> to complete your application. -->


### PR DESCRIPTION
This pull request makes the following changes:

- Unpublishes all prior DUB REU announcement blog posts, as they were confusing prospective applicants
- Creates a new landing page for the REU program, with an associated link on the top global navbar of the site
- Creates an FAQ page for the program

Going forward, we plan to update the landing page and the FAQ every year, rather than creating a new blog post or a page, to minimize potentially confusing out-of-date information.